### PR TITLE
Add command: show

### DIFF
--- a/etc/cli.yml
+++ b/etc/cli.yml
@@ -42,6 +42,51 @@ args:
         required: false
 
 subcommands:
+    - show:
+        about: Show the contents behind an ID
+        version: 0.1
+        author: Matthias Beyer <mail@beyermatthias.de>
+        args:
+            - id:
+                long: id
+                short: i
+                help: Show contents of this ID
+                required: false
+                takes_value: true
+
+            - match:
+                long: match
+                short: m
+                help: Show contents of files which match this regex
+                required: false
+                takes_value: true
+
+            - links:
+                long: links
+                help: Show links only, one link per line
+                required: false
+                takes_value: false
+
+            - meta:
+                long: meta
+                help: Show metadata of file, not contents
+                required: false
+                takes_value: false
+
+            - output_debug:
+                long: out-as-debug
+                short: d
+                help: Show contents as Debug output
+                required: false
+                takes_value: false
+
+            - output_json:
+                long: out-as-json
+                short: j
+                help: Show contents in JSON, if possible
+                required: false
+                takes_value: false
+
     - cal:
         about: Calendar module
         version: 0.1

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ pub use cli::CliConfig;
 pub use configuration::Configuration;
 pub use runtime::{ImagLogger, Runtime};
 pub use clap::App;
-pub use module::Module;
+pub use module::{Module, StoreFileInterfaceModule};
 
 pub mod cli;
 pub mod configuration;

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Debug, Formatter};
 use std::fmt;
+use std::rc::Rc;
+use std::cell::RefCell;
 use std::ops::Deref;
 
 use clap::ArgMatches;
@@ -7,6 +9,7 @@ use clap::ArgMatches;
 use runtime::Runtime;
 use module::{Link, Module};
 
+use storage::file::File;
 use storage::parser::FileHeaderParser;
 use storage::parser::Parser;
 use storage::json::parser::JsonHeaderParser;
@@ -14,6 +17,7 @@ use module::helpers::cli::create_tag_filter;
 use module::helpers::cli::create_hash_filter;
 use module::helpers::cli::create_text_header_field_grep_filter;
 use module::helpers::cli::CliFileFilter;
+use ui::file::FilePrinter;
 
 mod header;
 
@@ -342,6 +346,26 @@ impl<'a> Module<'a> for BM<'a> {
     fn links_in_file(&self, _: Rc<RefCell<File>>) -> Vec<Link> {
         debug!("Fetching links in file, though bookmarks cannot link");
         vec![]
+    }
+
+    fn print_file<P: FilePrinter>(&self, f: Rc<RefCell<File>>, p: P)
+        where Self: Sized
+    {
+        debug!("Printing file. As there is no content in bookmarks, printing nothing");
+        println!("");
+    }
+
+    fn print_links<P: FilePrinter>(&self, f: Rc<RefCell<File>>, p: P)
+        where Self: Sized
+    {
+        debug!("Printing links of file. As there are no links in bookmarks, printing nothing");
+        println!("");
+    }
+
+    fn print_meta<P: FilePrinter>(&self, f: Rc<RefCell<File>>, p: P)
+        where Self: Sized
+    {
+        unimplemented!()
     }
 
 }

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use clap::ArgMatches;
 
 use runtime::Runtime;
-use module::Module;
+use module::{Link, Module};
 
 use storage::parser::FileHeaderParser;
 use storage::parser::Parser;
@@ -338,6 +338,12 @@ impl<'a> Module<'a> for BM<'a> {
     fn runtime(&self) -> &Runtime {
         self.rt
     }
+
+    fn links_in_file(&self, _: Rc<RefCell<File>>) -> Vec<Link> {
+        debug!("Fetching links in file, though bookmarks cannot link");
+        vec![]
+    }
+
 }
 
 impl<'a> Debug for BM<'a> {

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use clap::ArgMatches;
 
 use runtime::Runtime;
-use module::{Link, Module};
+use module::{Module, Link, StoreFileInterfaceModule};
 
 use storage::file::File;
 use storage::parser::FileHeaderParser;
@@ -294,7 +294,7 @@ impl<'a> BM<'a> {
 /**
  * Trait implementation for BM module
  */
-impl<'a> Module<'a> for BM<'a> {
+impl<'a> Module for BM<'a> {
 
     fn exec(&self, matches: &ArgMatches) -> bool {
         use ansi_term::Colour::Red;
@@ -342,6 +342,13 @@ impl<'a> Module<'a> for BM<'a> {
     fn runtime(&self) -> &Runtime {
         self.rt
     }
+
+}
+
+/**
+ * Trait implementation for BM module
+ */
+impl<'a> StoreFileInterfaceModule<'a> for BM<'a> {
 
     fn links_in_file(&self, _: Rc<RefCell<File>>) -> Vec<Link> {
         debug!("Fetching links in file, though bookmarks cannot link");

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,12 +1,25 @@
+<<<<<<< 670f0e16e9c118e49d82346428adbf2c2d796907
 use std::fmt::Debug;
+=======
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use std::fmt::Result as FMTResult;
+use std::result::Result;
+use std::rc::Rc;
+use std::cell::RefCell;
+>>>>>>> Module trait: Add function to fetch links in a File
 
 use clap::ArgMatches;
 
 use runtime::Runtime;
+use storage::file::hash::FileHash;
 
 pub mod bm;
 pub mod helpers;
 pub mod notes;
+
+pub type Link = FileHash;
 
 /**
  * Module interface, each module has to implement this.
@@ -16,5 +29,8 @@ pub trait Module<'a> : Debug {
     fn name(&self) -> &'static str;
 
     fn runtime(&self) -> &Runtime;
+
+    fn links_in_file(&self, Rc<RefCell<File>>) -> Vec<Link>;
+
 }
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -13,7 +13,9 @@ use std::cell::RefCell;
 use clap::ArgMatches;
 
 use runtime::Runtime;
+use storage::file::File;
 use storage::file::hash::FileHash;
+use ui::file::FilePrinter;
 
 pub mod bm;
 pub mod helpers;
@@ -31,6 +33,18 @@ pub trait Module<'a> : Debug {
     fn runtime(&self) -> &Runtime;
 
     fn links_in_file(&self, Rc<RefCell<File>>) -> Vec<Link>;
+
+    fn print_file<P: FilePrinter>(&self, f: Rc<RefCell<File>>, p: P)
+        where Self: Sized
+    {
+        p.print_file(f);
+    }
+
+    fn print_links<P: FilePrinter>(&self, f: Rc<RefCell<File>>, p: P)
+        where Self: Sized;
+
+    fn print_meta<P: FilePrinter>(&self, f: Rc<RefCell<File>>, p: P)
+        where Self: Sized;
 
 }
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,6 +1,3 @@
-<<<<<<< 670f0e16e9c118e49d82346428adbf2c2d796907
-use std::fmt::Debug;
-=======
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
@@ -8,7 +5,6 @@ use std::fmt::Result as FMTResult;
 use std::result::Result;
 use std::rc::Rc;
 use std::cell::RefCell;
->>>>>>> Module trait: Add function to fetch links in a File
 
 use clap::ArgMatches;
 
@@ -26,11 +22,18 @@ pub type Link = FileHash;
 /**
  * Module interface, each module has to implement this.
  */
-pub trait Module<'a> : Debug {
+pub trait Module : Debug {
     fn exec(&self, matches: &ArgMatches) -> bool;
     fn name(&self) -> &'static str;
-
     fn runtime(&self) -> &Runtime;
+}
+
+/**
+ * Module interface, each module which is not a meta-module has to implement this.
+ *
+ * Meta-modules call modules and therefor don't need these functions
+ */
+pub trait StoreFileInterfaceModule<'a> : Module + Debug {
 
     fn links_in_file(&self, Rc<RefCell<File>>) -> Vec<Link>;
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -16,6 +16,7 @@ use ui::file::FilePrinter;
 pub mod bm;
 pub mod helpers;
 pub mod notes;
+pub mod show;
 
 pub type Link = FileHash;
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,8 +1,4 @@
-use std::collections::HashMap;
-use std::error::Error;
-use std::fmt::{Debug, Display, Formatter};
-use std::fmt::Result as FMTResult;
-use std::result::Result;
+use std::fmt::Debug;
 use std::rc::Rc;
 use std::cell::RefCell;
 

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -8,7 +8,7 @@ use clap::ArgMatches;
 
 mod header;
 
-use module::Module;
+use module::{Module, StoreFileInterfaceModule};
 use runtime::Runtime;
 use storage::file::File;
 use storage::parser::Parser;
@@ -441,7 +441,7 @@ impl<'a> Notes<'a> {
 
 }
 
-impl<'a> Module<'a> for Notes<'a> {
+impl<'a> Module for Notes<'a> {
 
     fn exec(&self, matches: &ArgMatches) -> bool {
         use ansi_term::Colour::Red;

--- a/src/module/show/mod.rs
+++ b/src/module/show/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Formatter};
 use std::fmt;
 
 use clap::ArgMatches;

--- a/src/module/show/mod.rs
+++ b/src/module/show/mod.rs
@@ -1,0 +1,50 @@
+use std::fmt::{Debug, Display, Formatter};
+use std::fmt;
+
+use clap::ArgMatches;
+
+use runtime::Runtime;
+pub use module::Module;
+
+pub struct Show<'a> {
+    rt: &'a Runtime<'a>,
+}
+
+impl<'a> Show<'a> {
+    pub fn new(rt: &'a Runtime<'a>) -> Show<'a> {
+        Show {
+            rt: rt,
+        }
+    }
+}
+
+impl<'a> Debug for Show<'a> {
+
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "Show");
+        Ok(())
+    }
+
+}
+
+impl<'a> Module for Show<'a> {
+
+    fn exec(&self, matches: &ArgMatches) -> bool {
+        // Fetch ID from CLI | Fetch regex from CLI
+        // Load files for (ID | regex)
+        // Check what should be printed (content, links, meta)
+        // Initiate FilePrinter
+        // Initialize appropriate Module
+        // Call printer function on module with File and printer
+        unimplemented!()
+    }
+
+    fn name(&self) -> &'static str {
+        "show"
+    }
+
+    fn runtime(&self) -> &Runtime {
+        &self.rt
+    }
+
+}

--- a/src/storage/path.rs
+++ b/src/storage/path.rs
@@ -30,7 +30,7 @@ struct Path<'a> {
     /*
      * The module
      */
-    module: &'a Module<'a>,
+    module: &'a Module,
 
     /*
      * The ID
@@ -43,7 +43,7 @@ struct Path<'a> {
 
 impl<'a> Path<'a> {
 
-    fn new(base: PathBuf, store: PathBuf, m: &'a Module<'a>, id: FileID) -> Path<'a> {
+    fn new(base: PathBuf, store: PathBuf, m: &'a Module, id: FileID) -> Path<'a> {
         Path {
             base:   base,
             store:  store,
@@ -54,7 +54,7 @@ impl<'a> Path<'a> {
         }
     }
 
-    fn new_with_idtype(base: PathBuf, store: PathBuf, m: &'a Module<'a>, id: FileIDType) -> Path<'a> {
+    fn new_with_idtype(base: PathBuf, store: PathBuf, m: &'a Module, id: FileIDType) -> Path<'a> {
         Path {
             base:   base,
             store:  store,
@@ -65,7 +65,7 @@ impl<'a> Path<'a> {
         }
     }
 
-    fn new_with_idhash(base: PathBuf, store: PathBuf, m: &'a Module<'a>, id: FileHash) -> Path<'a> {
+    fn new_with_idhash(base: PathBuf, store: PathBuf, m: &'a Module, id: FileHash) -> Path<'a> {
         Path {
             base:   base,
             store:  store,


### PR DESCRIPTION
Add a command "show" which is a module-independent way to print content of a file to the user.

Uses the modules behind the scenes to print the contents module-specific, but all the user has to know is the ID of a file.

Later this can also include search options to grep through the content of the files, or to grep through the header.