### PR TITLE
ImagLogger can be configured through the CLI only now

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,10 @@ fn main() {
     let yaml          = load_yaml!("../etc/cli.yml");
     let app           = App::from_yaml(yaml);
     let config        = CliConfig::new(app);
+
+    ImagLogger::init(&config);
+
     let configuration = Configuration::new(&config);
-    ImagLogger::init(&configuration, &config);
 
     debug!("Logger created!");
     debug!("CliConfig    : {:?}", &config);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,10 +20,10 @@ impl ImagLogger {
         }
     }
 
-    pub fn init(cfg: &Cfg, config: &CliConfig) -> Result<(), SetLoggerError> {
-        let lvl = if config.is_debugging() || cfg.is_debugging() {
+    pub fn init(config: &CliConfig) -> Result<(), SetLoggerError> {
+        let lvl = if config.is_debugging() {
             LogLevelFilter::Debug
-        } else if config.is_verbose() || cfg.is_debugging() {
+        } else if config.is_verbose() {
             LogLevelFilter::Info
         } else {
             LogLevelFilter::Error


### PR DESCRIPTION
The logger instance cannot be configured through the configuration file, as this is kinda bulky to use and we can log to debug much earlier now.