### PR TITLE
Config refactor

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -17,8 +17,6 @@ use cli::CliConfig;
 pub struct Configuration {
     pub rtp         : String,
     pub store_sub   : String,
-    pub verbose     : bool,
-    pub debugging   : bool,
     pub editor      : Option<String>,
     pub editor_opts : String,
 }
@@ -31,42 +29,22 @@ impl Configuration {
 
         let cfg = fetch_config(&rtp);
 
-        let verbose     = cfg.lookup_boolean("verbose").unwrap_or(false);
-        let debugging   = cfg.lookup_boolean("debug").unwrap_or(false);
         let store_sub   = String::from(cfg.lookup_str("store").unwrap_or("/store"));
         let editor      = cfg.lookup_str("editor").map(String::from);
         let editor_opts = String::from(cfg.lookup_str("editor-opts").unwrap_or(""));
 
         debug!("Building configuration");
-        debug!("  - verbose    : {}", verbose);
-        debug!("  - debugging  : {}", debugging);
         debug!("  - store sub  : {}", store_sub);
         debug!("  - runtimepath: {}", rtp);
         debug!("  - editor     : {:?}", editor);
         debug!("  - editor-opts: {}", editor_opts);
 
         Configuration {
-            verbose: verbose,
-            debugging: debugging,
             store_sub: store_sub,
             rtp: rtp,
             editor: editor,
             editor_opts: editor_opts,
         }
-    }
-
-    /**
-     * Check whether the configuration says we should run verbose
-     */
-    pub fn is_verbose(&self) -> bool {
-        self.verbose
-    }
-
-    /**
-     * Check whether the configuration says we should run in debugging
-     */
-    pub fn is_debugging(&self) -> bool {
-        self.debugging
     }
 
     /**
@@ -128,9 +106,7 @@ fn default_path() -> Option<String> {
 impl Debug for Configuration {
 
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "Configuration (verbose: {}, debugging: {}, rtp: {}, store path: {})",
-            self.is_verbose(),
-            self.is_debugging(),
+        write!(f, "Configuration (rtp: {}, store path: {})",
             self.get_rtp(),
             self.store_path()
             )

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -26,39 +26,22 @@ pub struct Configuration {
 impl Configuration {
 
     pub fn new(config: &CliConfig) -> Configuration {
-        let rtp = rtp_path(config).or(default_path());
+        let rtp = rtp_path(config).or(default_path()).unwrap_or(String::from("/tmp/"));
 
-        let mut verbose     = false;
-        let mut debugging   = false;
-        let mut store_sub   = String::from("/store");
-        let mut editor      = None;
-        let mut editor_opts = String::from("");
 
-        if let Some(cfg) = fetch_config(rtp.clone()) {
-            if let Some(v) = cfg.lookup_boolean("verbose") {
-                verbose = v;
-            }
-            if let Some(d) = cfg.lookup_boolean("debug") {
-                debugging = d;
-            }
-            if let Some(s) = cfg.lookup_str("store") {
-                store_sub = String::from(s);
-            }
-            if let Some(s) = cfg.lookup_str("editor") {
-                editor = Some(String::from(s));
-            }
-            if let Some(s) = cfg.lookup_str("editor-opts") {
-                editor_opts = String::from(s);
-            }
-        }
+        let cfg = fetch_config(&rtp);
 
-        let runtimepath = rtp.unwrap_or(String::from("/tmp/"));
+        let verbose     = cfg.lookup_boolean("verbose").unwrap_or(false);
+        let debugging   = cfg.lookup_boolean("debug").unwrap_or(false);
+        let store_sub   = String::from(cfg.lookup_str("store").unwrap_or("/store"));
+        let editor      = cfg.lookup_str("editor").map(String::from);
+        let editor_opts = String::from(cfg.lookup_str("editor-opts").unwrap_or(""));
 
         debug!("Building configuration");
         debug!("  - verbose    : {}", verbose);
         debug!("  - debugging  : {}", debugging);
         debug!("  - store sub  : {}", store_sub);
-        debug!("  - runtimepath: {}", runtimepath);
+        debug!("  - runtimepath: {}", rtp);
         debug!("  - editor     : {:?}", editor);
         debug!("  - editor-opts: {}", editor_opts);
 
@@ -66,7 +49,7 @@ impl Configuration {
             verbose: verbose,
             debugging: debugging,
             store_sub: store_sub,
-            rtp: runtimepath,
+            rtp: rtp,
             editor: editor,
             editor_opts: editor_opts,
         }
@@ -118,8 +101,15 @@ fn rtp_path(config: &CliConfig) -> Option<String> {
                       .and_then(|s| Some(String::from(s)))
 }
 
-fn fetch_config(rtp: Option<String>) -> Option<Cfg> {
-    rtp.and_then(|r| from_file(Path::new(&(r.clone() + "/config"))).ok())
+fn fetch_config(rtp: &String) -> Cfg {
+    use std::process::exit;
+
+    let configpath = format!("{}{}", rtp, "/config");
+    from_file(Path::new(&configpath)).map_err(|e| {
+        println!("Error loading config at '{}' -> {:?}", configpath, e);
+        println!("Exiting now.");
+        exit(1)
+    }).unwrap()
 }
 
 /**

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -77,14 +77,14 @@ impl<'a> Runtime<'a> {
      * Check whether we run verbose
      */
     pub fn is_verbose(&self) -> bool {
-        self.config.is_verbose() || self.configuration.is_verbose()
+        self.config.is_verbose()
     }
 
     /**
      * Check whether we run in debugging
      */
     pub fn is_debugging(&self) -> bool {
-        self.config.is_debugging() || self.configuration.is_verbose()
+        self.config.is_debugging()
     }
 
     /**


### PR DESCRIPTION
Refactoring of the internal representation of the configuration file.

Also removes the possibility to set verbosity and debugging flag in the config file, as I consider this bad anyways and it allows us now to setup the logger earlier in the startup phase, which means more code which can use debugging output.