### PR TITLE
Turn warning into hard errors and fix them

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![deny(unused_variables)]
 #![deny(unused_must_use)]
 #![deny(unused_mut)]
+#![deny(non_shorthand_field_patterns)]
 
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+#![deny(unused_imports)]
+#![deny(unused_variables)]
+#![deny(unused_must_use)]
+#![deny(unused_mut)]
+
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
 
     ImagLogger::init(&config).map_err(|e| {
         error!("Could not initialize logger");
+        debug!("Could not initialize logger: {:?}", e);
         exit(1);
     }).ok();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,13 +37,17 @@ pub use module::bm::BM;
 pub use module::notes::Notes;
 
 fn main() {
+    use std::process::exit;
     use ansi_term::Colour::Yellow;
 
     let yaml          = load_yaml!("../etc/cli.yml");
     let app           = App::from_yaml(yaml);
     let config        = CliConfig::new(app);
 
-    ImagLogger::init(&config);
+    ImagLogger::init(&config).map_err(|e| {
+        error!("Could not initialize logger");
+        exit(1);
+    }).ok();
 
     let configuration = Configuration::new(&config);
 

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -13,7 +13,6 @@ use storage::json::parser::JsonHeaderParser;
 use module::helpers::cli::create_tag_filter;
 use module::helpers::cli::create_hash_filter;
 use module::helpers::cli::create_text_header_field_grep_filter;
-use module::helpers::cli::create_content_grep_filter;
 use module::helpers::cli::CliFileFilter;
 
 mod header;

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -293,7 +293,7 @@ impl<'a> BM<'a> {
 impl<'a> Module<'a> for BM<'a> {
 
     fn exec(&self, matches: &ArgMatches) -> bool {
-        use ansi_term::Colour::{Green, Yellow, Red};
+        use ansi_term::Colour::{Yellow, Red};
 
         match matches.subcommand_name() {
             Some("add") => {

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -293,7 +293,7 @@ impl<'a> BM<'a> {
 impl<'a> Module<'a> for BM<'a> {
 
     fn exec(&self, matches: &ArgMatches) -> bool {
-        use ansi_term::Colour::{Yellow, Red};
+        use ansi_term::Colour::Red;
 
         match matches.subcommand_name() {
             Some("add") => {

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -155,7 +155,7 @@ impl<'a> BM<'a> {
      * Subcommand: open
      */
     fn command_open(&self, matches: &ArgMatches) -> bool {
-        use ansi_term::Colour::{Green, Yellow, Red};
+        use ansi_term::Colour::{Green, Red};
         use open;
 
         let parser = Parser::new(JsonHeaderParser::new(None));

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -280,7 +280,7 @@ impl<'a> BM<'a> {
         use self::header::rebuild_header_with_tags;
 
         let parser = Parser::new(JsonHeaderParser::new(None));
-        alter_tags_in_files(self, matches, &parser, |old_tags, cli_tags| {
+        alter_tags_in_files(self, matches, &parser, |_, cli_tags| {
             cli_tags.clone()
         }, rebuild_header_with_tags)
     }

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Debug, Formatter};
 use std::fmt;
 use std::ops::Deref;
-use std::process::exit;
 
 use clap::ArgMatches;
 

--- a/src/module/bm/mod.rs
+++ b/src/module/bm/mod.rs
@@ -203,7 +203,7 @@ impl<'a> BM<'a> {
      * Subcommand: remove
      */
     fn command_remove(&self, matches: &ArgMatches) -> bool {
-        use ansi_term::Colour::{Green, Yellow, Red};
+        use ansi_term::Colour::{Green, Red};
 
         let parser = Parser::new(JsonHeaderParser::new(None));
 

--- a/src/module/helpers/cli.rs
+++ b/src/module/helpers/cli.rs
@@ -8,9 +8,6 @@ use regex::Regex;
 
 use storage::file::File;
 use storage::file::hash::FileHash;
-use storage::json::parser::JsonHeaderParser;
-use storage::parser::FileHeaderParser;
-use storage::parser::Parser;
 
 pub trait CliFileFilter {
 

--- a/src/module/helpers/content.rs
+++ b/src/module/helpers/content.rs
@@ -32,8 +32,8 @@ pub mod markdown {
     impl Render for LinkExtractRenderer {
 
         fn link(&mut self,
-                output: &mut Buffer,
-                content: &Buffer,
+                _: &mut Buffer,
+                _: &Buffer,
                 link: &Buffer,
                 title: &Buffer) -> bool {
 

--- a/src/module/helpers/header/mod.rs
+++ b/src/module/helpers/header/mod.rs
@@ -47,7 +47,7 @@ pub mod data {
                 let mut keys : Vec<FHD> = ks.clone();
                 keys.iter().find(|k| {
                     match k.deref() {
-                        &FHD::Key{name: ref n, value: ref v} => n == name,
+                        &FHD::Key{name: ref n, value: _} => n == name,
                         _ => false
                     }
                 }).and_then(|urlkey| {

--- a/src/module/helpers/header/mod.rs
+++ b/src/module/helpers/header/mod.rs
@@ -44,12 +44,13 @@ pub mod data {
     pub fn get_named_text_from_header(name: &'static str, header: &FHD) -> Option<String> {
         match header {
             &FHD::Map{keys: ref ks} => {
-                let mut keys : Vec<FHD> = ks.clone();
-                keys.iter().find(|k| {
-                    match k.deref() {
-                        &FHD::Key{name: ref n, value: _} => n == name,
-                        _ => false
-                    }
+                ks.clone()
+                    .iter()
+                    .find(|k| {
+                        match k.deref() {
+                            &FHD::Key{name: ref n, value: _} => n == name,
+                            _ => false
+                        }
                 }).and_then(|urlkey| {
                     match urlkey.deref().clone() {
                         FHD::Key{name: ref n, value: ref v} => {

--- a/src/module/helpers/header/tags.rs
+++ b/src/module/helpers/header/tags.rs
@@ -61,7 +61,7 @@ pub mod data {
      * Does no spec verification.
      */
     pub fn get_tags_from_header(header: &FHD) -> Vec<String> {
-        let mut tags : Vec<String> = vec![];
+        let tags : Vec<String> = vec![];
 
         fn match_array(a: &Box<FHD>) -> Vec<String> {
             let mut tags : Vec<String> = vec![];

--- a/src/module/helpers/header/tags.rs
+++ b/src/module/helpers/header/tags.rs
@@ -118,7 +118,6 @@ pub mod data {
         use module::helpers::cli::create_tag_filter;
         use module::helpers::cli::create_hash_filter;
         use module::helpers::cli::create_text_header_field_grep_filter;
-        use module::helpers::cli::create_content_grep_filter;
         use module::helpers::cli::CliFileFilter;
 
         let cli_tags = matches.value_of("tags")

--- a/src/module/helpers/header/tags.rs
+++ b/src/module/helpers/header/tags.rs
@@ -87,7 +87,7 @@ pub mod data {
                 let keys : Vec<FHD> = ks.clone();
                 for key in keys {
                     match key {
-                        FHD::Key{name: ref name, value: ref v} => {
+                        FHD::Key{ref name, value: ref v} => {
                             if name == "TAGS" {
                                 return match_array(v)
                             }

--- a/src/module/helpers/utils.rs
+++ b/src/module/helpers/utils.rs
@@ -4,8 +4,6 @@
 pub mod cli {
     use clap::ArgMatches;
 
-    use runtime::Runtime;
-
     /**
      * Get a commandline option "tags" and split the argument by "," to be able to provide a
      * Vec<String> with the argument as array.

--- a/src/module/helpers/utils.rs
+++ b/src/module/helpers/utils.rs
@@ -10,7 +10,7 @@ pub mod cli {
      * Get a commandline option "tags" and split the argument by "," to be able to provide a
      * Vec<String> with the argument as array.
      */
-    pub fn get_tags<'a>(rt: &Runtime, sub: &ArgMatches<'a, 'a>) -> Vec<String> {
+    pub fn get_tags<'a>(sub: &ArgMatches<'a, 'a>) -> Vec<String> {
 
         fn reject_if_with_spaces(e: &String) -> bool {
             if e.contains(" ") {

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -276,7 +276,6 @@ impl<'a> Notes<'a> {
         debug!("list internal links = {}", list_intern);
         debug!("list external links = {}", list_extern);
 
-        let printer = TablePrinter::new(self.rt.is_verbose(), self.rt.is_debugging());
         let titles = row!["#", "Text", "Link", "Direction"];
         let mut table = Table::new();
         table.set_titles(titles);

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -496,7 +496,7 @@ impl<'a> Module<'a> for Notes<'a> {
 impl<'a> Debug for Notes<'a> {
 
     fn fmt(&self, fmt: &mut Formatter) -> FMTResult {
-        write!(fmt, "[Module][Notes]");
+        try!(write!(fmt, "[Module][Notes]"));
         Ok(())
     }
 

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use std::ops::Deref;
 
 use clap::ArgMatches;
-use regex::Regex;
 
 mod header;
 

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -216,7 +216,6 @@ impl<'a> Notes<'a> {
     }
 
     fn command_list(&self, matches: &ArgMatches) -> bool {
-        use ansi_term::Colour::{Red, Green};
         use ui::file::{FilePrinter, TablePrinter};
         use self::header::get_name_from_header;
         use self::header::get_tags_from_header;

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -219,7 +219,6 @@ impl<'a> Notes<'a> {
         use ui::file::{FilePrinter, TablePrinter};
         use self::header::get_name_from_header;
         use self::header::get_tags_from_header;
-        use std::process::exit;
         use module::helpers::cli::CliFileFilter;
 
         let parser  = Parser::new(JsonHeaderParser::new(None));

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -256,7 +256,7 @@ impl<'a> Notes<'a> {
     fn command_links(&self, matches: &ArgMatches) -> bool {
         use ansi_term::Colour::{Red, Green};
         use module::helpers::content::markdown::MarkdownParser;
-        use ui::file::{FilePrinter, TablePrinter};
+        use ui::file::FilePrinter;
         use util::is_url;
         use prettytable::Table;
         use prettytable::row::Row;

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Debug, Formatter};
 use std::fmt::Result as FMTResult;
-use std::rc::Rc;
 use std::ops::Deref;
 
 use clap::ArgMatches;

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -211,7 +211,12 @@ impl<'a> Notes<'a> {
             }
         };
 
-        tempfile.write_all(MarkdownParser::new(&s).to_html_page().as_ref());
+        tempfile.write_all(MarkdownParser::new(&s).to_html_page().as_ref())
+                .map_err(|e| {
+                    error!("Could not write HTML to file: {}", temppath);
+                    debug!("Could not write HTML to file: {:?}", e);
+                })
+                .ok();
         open::that(&temppath[..]).is_ok()
     }
 

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -311,7 +311,6 @@ impl<'a> Notes<'a> {
             })
             .flatten()
             .filter(|link| {
-                let title       = &link.title;
                 let url         = &link.url;
                 let is_extern   = is_url(&url);
                 debug!("Is external URL {} -> {}", url, is_extern);

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Debug, Formatter};
 use std::fmt::Result as FMTResult;
 use std::ops::Deref;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 use clap::ArgMatches;
 
@@ -8,6 +10,7 @@ mod header;
 
 use module::Module;
 use runtime::Runtime;
+use storage::file::File;
 use storage::parser::Parser;
 use storage::json::parser::JsonHeaderParser;
 use module::helpers::cli::create_tag_filter;

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -9,7 +9,6 @@ mod header;
 
 use module::Module;
 use runtime::Runtime;
-use storage::file::File;
 use storage::parser::Parser;
 use storage::json::parser::JsonHeaderParser;
 use module::helpers::cli::create_tag_filter;

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -435,7 +435,7 @@ impl<'a> Notes<'a> {
         use self::header::rebuild_header_with_tags;
 
         let parser = Parser::new(JsonHeaderParser::new(None));
-        alter_tags_in_files(self, matches, &parser, |old_tags, cli_tags| {
+        alter_tags_in_files(self, matches, &parser, |_, cli_tags| {
             cli_tags.clone()
         }, rebuild_header_with_tags)
     }

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -30,7 +30,6 @@ impl<'a> Notes<'a> {
     }
 
     fn command_add(&self, matches: &ArgMatches) -> bool {
-        use std::process::exit;
         use ansi_term::Colour::Yellow;
         use self::header::build_header;
         use ui::external::editor::let_user_provide_content;

--- a/src/module/notes/mod.rs
+++ b/src/module/notes/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Debug, Formatter};
 use std::fmt::Result as FMTResult;
 use std::rc::Rc;
-use std::cell::RefCell;
 use std::ops::Deref;
 
 use clap::ArgMatches;

--- a/src/storage/file/hash.rs
+++ b/src/storage/file/hash.rs
@@ -60,7 +60,7 @@ impl Into<String> for FileHash {
 impl Display for FileHash {
 
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.hash);
+        try!(write!(fmt, "{}", self.hash));
         Ok(())
     }
 

--- a/src/storage/file/id.rs
+++ b/src/storage/file/id.rs
@@ -68,9 +68,9 @@ impl FileID {
             }
             debug!("Matches: {}", capts.len());
 
-            let modname     = capts.at(1).unwrap();
-            let hashname    = capts.at(2).unwrap();
-            let mut hash    = capts.at(3).unwrap();
+            let modname  = capts.at(1).unwrap();
+            let hashname = capts.at(2).unwrap();
+            let hash     = capts.at(3).unwrap();
 
             debug!("Destructure FilePath to ID:");
             debug!("                  FilePath: {:?}", s);

--- a/src/storage/file/id.rs
+++ b/src/storage/file/id.rs
@@ -169,7 +169,12 @@ mod test {
             let lvl = LogLevelFilter::Debug;
             max_log_lvl.set(lvl);
             Box::new(ImagLogger::new(lvl.to_log_level().unwrap()))
-        });
+        })
+        .map_err(|e| {
+            println!("Error setting logger: {:?}", e);
+            assert!(false);
+        })
+        .ok();
         debug!("Init logger for test");
     }
 

--- a/src/storage/file/id_type.rs
+++ b/src/storage/file/id_type.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Display, Formatter};
 use std::fmt;
 use std::convert::{From, Into};
 use std::str::FromStr;

--- a/src/storage/file/mod.rs
+++ b/src/storage/file/mod.rs
@@ -128,7 +128,7 @@ mod test {
     // we use the JSON parser here, so we can generate FileHeaderData
     use storage::json::parser::JsonHeaderParser;
     use storage::file::header::match_header_spec;
-    use storage::parser::{FileHeaderParser, ParserError};
+    use storage::parser::FileHeaderParser;
     use storage::file::header::data::FileHeaderData as FHD;
     use storage::file::header::spec::FileHeaderSpec as FHS;
 

--- a/src/storage/file/mod.rs
+++ b/src/storage/file/mod.rs
@@ -129,7 +129,6 @@ mod test {
     use storage::json::parser::JsonHeaderParser;
     use storage::file::header::match_header_spec;
     use storage::parser::FileHeaderParser;
-    use storage::file::header::data::FileHeaderData as FHD;
     use storage::file::header::spec::FileHeaderSpec as FHS;
 
     #[test]

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -153,7 +153,7 @@ mod test {
     use std::ops::Deref;
 
     use super::JsonHeaderParser;
-    use storage::parser::{FileHeaderParser, ParserError};
+    use storage::parser::FileHeaderParser;
     use storage::file::header::data::FileHeaderData as FHD;
     use storage::file::header::spec::FileHeaderSpec as FHS;
 

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -221,7 +221,7 @@ mod test {
         use std::ops::Deref;
 
         match k {
-            &FHD::Key{name: ref name, value: ref value} => {
+            &FHD::Key{ref name, ref value} => {
                 assert!(name == "a" || name == "b", "Key unknown");
                 match value.deref() {
                     &FHD::Array{values: ref vs} => {

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -178,7 +178,7 @@ mod test {
         assert!(parsed.is_ok(), "Parsed is not ok: {:?}", parsed);
 
         match parsed.ok() {
-            Some(FHD::Map{keys: keys}) => {
+            Some(FHD::Map{keys}) => {
                 for k in keys {
                     match k {
                         FHD::Key{name: name, value: value} => {

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -224,8 +224,8 @@ mod test {
             &FHD::Key{ref name, ref value} => {
                 assert!(name == "a" || name == "b", "Key unknown");
                 match value.deref() {
-                    &FHD::Array{values: ref vs} => {
-                        for value in vs.iter() {
+                    &FHD::Array{ref values} => {
+                        for value in values.iter() {
                             match value {
                                 &FHD::UInteger(u) => assert_eq!(u, 1),
                                 _ => assert!(false, "UInt is not an UInt"),
@@ -233,8 +233,8 @@ mod test {
                         }
                     }
 
-                    &FHD::Map{keys: ref ks} => {
-                        for key in ks.iter() {
+                    &FHD::Map{ref keys} => {
+                        for key in keys.iter() {
                             match key {
                                 &FHD::Key{ref name, ref value} => {
                                     match value.deref() {

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -181,7 +181,7 @@ mod test {
             Some(FHD::Map{keys}) => {
                 for k in keys {
                     match k {
-                        FHD::Key{name: name, value: value} => {
+                        FHD::Key{name, value} => {
                             assert!(name == "a" || name == "b", "Key unknown");
                             match value.deref() {
                                 &FHD::UInteger(u) => assert_eq!(u, 1),

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -138,7 +138,7 @@ impl Serialize for FileHeaderData {
 
                 hm.serialize(ser)
             },
-            &FileHeaderData::Key{name: ref n, value: ref v} => unreachable!(),
+            &FileHeaderData::Key{name: _, value: _} => unreachable!(),
 
         }
     }

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -70,7 +70,9 @@ impl FileHeaderParser for JsonHeaderParser {
         let mut s = Vec::<u8>::new();
         {
             let mut ser = Serializer::pretty(&mut s);
-            data.serialize(&mut ser);
+            data.serialize(&mut ser).map_err(|e| {
+                debug!("Serializer error: {:?}", e);
+            }).ok();
         }
 
         String::from_utf8(s).or(

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -207,7 +207,7 @@ mod test {
         assert!(parsed.is_ok(), "Parsed is not ok: {:?}", parsed);
 
         match parsed.ok() {
-            Some(FHD::Map{keys: keys}) => {
+            Some(FHD::Map{keys}) => {
                 for k in keys {
                     match_key(&k);
                 }

--- a/src/storage/json/parser.rs
+++ b/src/storage/json/parser.rs
@@ -236,7 +236,7 @@ mod test {
                     &FHD::Map{keys: ref ks} => {
                         for key in ks.iter() {
                             match key {
-                                &FHD::Key{name: ref name, value: ref value} => {
+                                &FHD::Key{ref name, ref value} => {
                                     match value.deref() {
                                         &FHD::Integer(i) => {
                                             assert_eq!(i, -2);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -218,7 +218,10 @@ impl Store {
 
         FSFile::open(&path).map(|mut file| {
             file.read_to_string(&mut string)
-                .map_err(|e| error!("Failed reading file: '{}'", path))
+                .map_err(|e| {
+                    error!("Failed reading file: '{}'", path);
+                    debug!("    error {}", e);
+                })
                 .is_ok();
         });
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -223,7 +223,11 @@ impl Store {
                     debug!("    error {}", e);
                 })
                 .is_ok();
-        });
+        })
+        .map_err(|e| {
+            error!("Error opening file: {}", path);
+            debug!("Error opening file: {:?}", e);
+        }).ok();
 
         parser.read(string).map(|(header, data)| {
             self.new_file_from_parser_result(m, id.clone(), header, data);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -327,7 +327,12 @@ impl Store {
                     });
                 }
             }
-        });
+        })
+        .map_err(|e| {
+            error!("Could not glob: '{}'", globstr);
+            debug!("Could not glob(): {:?}", e);
+        })
+        .ok();
         res
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -217,7 +217,8 @@ impl Store {
 
         FSFile::open(&path).map(|mut file| {
             file.read_to_string(&mut string)
-                .map_err(|e| error!("Failed reading file: '{}'", path));
+                .map_err(|e| error!("Failed reading file: '{}'", path))
+                .is_ok();
         });
 
         parser.read(string).map(|(header, data)| {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -179,6 +179,7 @@ impl Store {
             fsfile.write_all(&text.unwrap().clone().into_bytes()[..])
         }).map_err(|writeerr|  {
             debug!("Could not create file at '{}'", path);
+            debug!("    error: {:?}", writeerr);
         }).and(Ok(true)).unwrap()
 
         // TODO: Is this unwrap() save?

--- a/src/storage/parser.rs
+++ b/src/storage/parser.rs
@@ -125,9 +125,8 @@ impl<HP: FileHeaderParser> Parser<HP> {
 
         if divided.is_err() {
             debug!("Error reading into internal datastructure");
-            let mut p = ParserError::new("Dividing text failed",
-                                         s, 0,
-                    "Dividing text with divide_text() failed");
+            let p = ParserError::new("Dividing text failed", s, 0,
+                                     "Dividing text with divide_text() failed");
             return Err(p.with_cause(Box::new(divided.err().unwrap())));
         }
 

--- a/src/ui/external/editor.rs
+++ b/src/ui/external/editor.rs
@@ -7,6 +7,7 @@ use runtime::Runtime;
 pub fn let_user_provide_content(rt: &Runtime) -> Option<String> {
     use std::io::Read;
     use std::fs::File;
+    use std::process::exit;
 
     let filepath        = "/tmp/imag-tmp.md";
     let file_created    = File::create(filepath)
@@ -44,7 +45,13 @@ pub fn let_user_provide_content(rt: &Runtime) -> Option<String> {
 
     let mut contents = String::new();
     File::open(filepath).map(|mut file| {
-        file.read_to_string(&mut contents);
+        file.read_to_string(&mut contents)
+            .map_err(|e| {
+                error!("Error reading content: {}", e);
+                debug!("Error reading content: {:?}", e);
+                exit(1);
+            })
+            .is_ok();
         Some(contents)
     }).unwrap_or(None)
 }

--- a/src/ui/external/editor.rs
+++ b/src/ui/external/editor.rs
@@ -7,7 +7,6 @@ use runtime::Runtime;
 pub fn let_user_provide_content(rt: &Runtime) -> Option<String> {
     use std::io::Read;
     use std::fs::File;
-    use std::process::Command;
 
     let filepath        = "/tmp/imag-tmp.md";
     let file_created    = File::create(filepath)

--- a/src/ui/external/editor.rs
+++ b/src/ui/external/editor.rs
@@ -73,7 +73,12 @@ pub fn edit_content(rt: &Runtime, old_content: String) -> (String, bool) {
             }
         };
 
-        file.write(old_content.as_ref());
+        file.write(old_content.as_ref())
+            .map_err(|e| {
+                error!("Error writing content: {}", e);
+                debug!("Error writing content: {:?}", e);
+                exit(1);
+            }).is_ok();
     }
     debug!("Ready with putting old content into the file");
 

--- a/src/ui/external/editor.rs
+++ b/src/ui/external/editor.rs
@@ -65,7 +65,6 @@ pub fn edit_content(rt: &Runtime, old_content: String) -> (String, bool) {
     use std::io::Read;
     use std::io::Write;
     use std::fs::File;
-    use std::process::Command;
     use std::process::exit;
 
     let filepath = "/tmp/imag-tmp.md";

--- a/src/ui/external/editor.rs
+++ b/src/ui/external/editor.rs
@@ -101,7 +101,11 @@ pub fn edit_content(rt: &Runtime, old_content: String) -> (String, bool) {
 
     let mut contents = String::new();
     File::open(filepath).map(|mut file| {
-        file.read_to_string(&mut contents);
+        file.read_to_string(&mut contents).map_err(|e| {
+            error!("Error reading content: {}", e);
+            debug!("Error reading content: {:?}", e);
+            exit(1);
+        }).is_ok();
         (contents, true)
     }).unwrap_or((old_content, false))
 }


### PR DESCRIPTION
Finally, I cleaned up a bit.

The `dead_code` warning is still disabled, though I might enable it anytime soon.