### PR TITLE
Notes show

### DIFF
--- a/etc/cli.yml
+++ b/etc/cli.yml
@@ -314,6 +314,45 @@ subcommands:
                         required: false
                         takes_value: true
 
+            - show:
+                about: Show note(s)
+                version: 0.1
+                author: Matthias Beyer <mail@beyermatthias.de>
+                args:
+                    - plain:
+                        long: plain
+                        short: p
+                        help: Show notes plain (like with 'cat')
+                        required: false
+                        takes_value: false
+
+                    - id:
+                        long: id
+                        help: Open note with this ID
+                        required: false
+                        takes_value: true
+
+                    - namegrep:
+                        short: n
+                        long: name
+                        help: Open where name matches this regex
+                        required: false
+                        takes_value: true
+
+                    - grep:
+                        short: g
+                        long: grep
+                        help: Open where grep with regex finds something
+                        required: false
+                        takes_value: true
+
+                    - tags:
+                        short: t
+                        long: tags
+                        help: Open all notes with these tags
+                        required: false
+                        takes_value: true
+
             - open:
                 about: Open notes as HTML page in browser (via XDG-open)
                 version: 0.1


### PR DESCRIPTION
Add subcommand for `notes`: `show`, to print notes on the commandline, unrendered.