### PR TITLE
travis: exit(0) if there are only changes in ./doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ matrix:
     allow_failures:
         - rust: nightly
 
+before_install:
+    - |
+      c=$(git diff $TRAVIS_BRANCH..$TRAVIS_COMMIT --name-only | cut -d "/" -f 1 | uniq)
+      if [[ "$c" == "doc" ]]; then
+          echo "Only changes in DOC, exiting 0"
+          exit 0
+      else
+        echo "Changes in other directories than ./doc"
+        echo "continue build..."
+      fi
+
 before_script:
     - |
         pip install 'travis-cargo<0.2' --user &&


### PR DESCRIPTION
Optimize the CI-time for `./doc` changes by not doing anything if there are only changes in `./doc`.

@TheNeikos careful review would be appreciated!