### PR TITLE
Dont pass the table to the header object, but generate it in ::new()

### DIFF
--- a/libimagstore/src/header.rs
+++ b/libimagstore/src/header.rs
@@ -1,7 +1,11 @@
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::result::Result as RResult;
 
 use toml::{Table, Value};
+
+use self::error::ParserErrorKind;
+use self::error::ParserError;
 
 pub mod error {
     use std::fmt::{Debug, Display, Formatter};
@@ -68,10 +72,6 @@ pub mod error {
 
 }
 
-
-use self::error::ParserErrorKind;
-use self::error::ParserError;
-
 /**
  * EntryHeader
  *
@@ -92,10 +92,12 @@ impl EntryHeader {
 
     /**
      * Get a new header object with a already-filled toml table
+     *
+     * Default header values are inserted into the header object by default.
      */
-    pub fn new(toml: Table) -> EntryHeader {
+    pub fn new() -> EntryHeader {
         EntryHeader {
-            toml: toml,
+            toml: BTreeMap::new(),
         }
     }
 
@@ -113,7 +115,11 @@ impl EntryHeader {
         parser.parse()
             .ok_or(ParserError::new(ParserErrorKind::TOMLParserErrors, None))
             .and_then(|t| verify_header_consistency(t))
-            .map(|t| EntryHeader::new(t))
+            .map(|t| {
+                EntryHeader {
+                    toml: t
+                }
+            })
     }
 
 }

--- a/libimagstore/src/header.rs
+++ b/libimagstore/src/header.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::result::Result as RResult;
 
-use toml::{Table, Value};
+use toml::{Array, Table, Value};
+use version;
 
 use self::error::ParserErrorKind;
 use self::error::ParserError;
@@ -97,7 +98,7 @@ impl EntryHeader {
      */
     pub fn new() -> EntryHeader {
         EntryHeader {
-            toml: BTreeMap::new(),
+            toml: build_default_header(),
         }
     }
 
@@ -287,5 +288,20 @@ mod test {
 
         assert!(verify_header_consistency(header).is_ok());
     }
+}
+
+fn build_default_header() -> BTreeMap<String, Value> {
+    let mut m = BTreeMap::new();
+
+    m.insert(String::from("imag"), {
+        let mut imag_map = BTreeMap::<String, Value>::new();
+
+        imag_map.insert(String::from("version"), Value::String(version!()));
+        imag_map.insert(String::from("links"), Value::Array(vec![]));
+
+        Value::Table(imag_map)
+    });
+
+    m
 }
 


### PR DESCRIPTION
Closes #127 

I will not merge this yet, as we have to build the default-header. I will implement it as far as the docs say by now, but maybe we want more...