### PR TITLE
rt: Make runtime module public

### DIFF
--- a/libimagrt/src/lib.rs
+++ b/libimagrt/src/lib.rs
@@ -10,5 +10,6 @@ extern crate libimagutil;
 
 mod configuration;
 mod logger;
-mod runtime;
+
+pub mod runtime;
 


### PR DESCRIPTION
Make the `runtime` module of `libimagrt` public, so we can use the `Runtime` type.