### PR TITLE
Fix: Add missing "pub" on Entry functions

### DIFF
--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -347,7 +347,7 @@ pub struct Entry {
 
 impl Entry {
 
-    fn new(loc: StoreId) -> Entry {
+    pub fn new(loc: StoreId) -> Entry {
         Entry {
             location: loc,
             header: EntryHeader::new(),
@@ -355,7 +355,7 @@ impl Entry {
         }
     }
 
-    fn from_file(loc: StoreId, file: &mut File) -> Result<Entry> {
+    pub fn from_file(loc: StoreId, file: &mut File) -> Result<Entry> {
         let text = {
             use std::io::Read;
             let mut s = String::new();
@@ -365,7 +365,7 @@ impl Entry {
         Self::from_str(loc, &text[..])
     }
 
-    fn from_str(loc: StoreId, s: &str) -> Result<Entry> {
+    pub fn from_str(loc: StoreId, s: &str) -> Result<Entry> {
         let re = Regex::new(r"(?smx)
             ^---$
             (?P<header>.*) # Header


### PR DESCRIPTION
Add missing `pub` keywords on a few `Entry` functions.