### PR TITLE
Add missing error handling

### DIFF
--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -193,6 +193,10 @@ impl Store {
     /// Delete an entry
     pub fn delete(&self, id: StoreId) -> Result<()> {
         let mut entries_lock = self.entries.write();
+        if entries_lock.is_err() {
+            return Err(StoreError::new(StoreErrorKind::LockPoisoned, None))
+        }
+
         let mut entries = entries_lock.unwrap();
 
         // if the entry is currently modified by the user, we cannot drop it


### PR DESCRIPTION
We don't want to panick if a lock inside the store is broken. We want to
notify the user, so she can start panicking.