### PR TITLE
Fix: Make IntoStoreId public

### DIFF
--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -6,7 +6,7 @@ pub type StoreId = PathBuf;
 
 /// This Trait allows you to convert various representations to a single one
 /// suitable for usage in the Store
-trait IntoStoreId {
+pub trait IntoStoreId {
     fn into_storeid(self) -> StoreId;
 }
 


### PR DESCRIPTION
Fixes private `IntoStoreId` trait which should be public.