### PR TITLE
Remove unused imports

### DIFF
--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -1,5 +1,4 @@
 use std::default::Default;
-use std::fmt::{Debug, Display, Formatter, Error};
 use std::path::PathBuf;
 use std::result::Result as RResult;
 
@@ -159,7 +158,6 @@ impl Configuration {
  * Tests several variants for the config file path and uses the first one which works.
  */
 fn fetch_config(rtp: &PathBuf) -> Result<Config> {
-    use std::process::exit;
     use std::env;
 
     use xdg_basedir;

--- a/libimagrt/src/error.rs
+++ b/libimagrt/src/error.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RuntimeErrorKind {

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::result::Result as RResult;
 
 pub use clap::App;
 

--- a/libimagstore/src/error.rs
+++ b/libimagstore/src/error.rs
@@ -4,7 +4,6 @@ use std::clone::Clone;
 use std::fmt::{Debug, Display, Formatter};
 use std::fmt;
 use std::convert::From;
-use toml;
 
 /**
  * Kind of store error

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -5,11 +5,9 @@ use std::path::PathBuf;
 use std::result::Result as RResult;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::error::Error;
 use std::collections::BTreeMap;
 use std::io::{Seek, SeekFrom};
 
-use fs2::FileExt;
 use toml::{Table, Value};
 use regex::Regex;
 


### PR DESCRIPTION
Removes unused imports.

We really should enable the appropriate checks for this. @TheNeikos feel free to submit a PR for denying unused imports.