### PR TITLE
Libimagstore/git layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ script:
 addons:
     apt:
         packages:
+            - cmake
             - libcurl4-openssl-dev
             - libdw-dev
             - libelf-dev
@@ -81,6 +82,8 @@ addons:
             - openssl
             - pkgconfig
             - tree
+        sources:
+            - kalakris-cmake
 
 after_success:
     - travis-cargo --only stable doc-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,11 @@ addons:
     apt:
         packages:
             - libcurl4-openssl-dev
-            - libelf-dev
             - libdw-dev
+            - libelf-dev
+            - libgit2
+            - libssh2
+            - openssl
             - tree
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ addons:
             - libgit2
             - libssh2
             - openssl
+            - pkgconfig
             - tree
 
 after_success:

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,10 @@ let
     rustc
     cargo
     pkgs.llvmPackages.lldb
+    pkgs.libgit2
+    pkgs.libssh2
+    pkgs.openssl
+    pkgs.pkgconfig
   ];
 in
 

--- a/libimagstore/Cargo.toml
+++ b/libimagstore/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 [dependencies]
 fs2 = "0.2.2"
+git2 = "0.3.4"
 glob = "0.2.10"
 log = "0.3.5"
 regex = "0.1.47"

--- a/libimagstore/src/error.rs
+++ b/libimagstore/src/error.rs
@@ -28,6 +28,7 @@ pub enum StoreErrorKind {
     HeaderPathTypeFailure,
     HeaderKeyNotFound,
     HeaderTypeFailure,
+    GitError,
         // maybe more
 }
 
@@ -52,6 +53,7 @@ fn store_error_type_as_str(e: &StoreErrorKind) -> &'static str {
         &StoreErrorKind::HeaderPathTypeFailure => "Header has wrong type for path",
         &StoreErrorKind::HeaderKeyNotFound     => "Header Key not found",
         &StoreErrorKind::HeaderTypeFailure     => "Header type is wrong",
+        &StoreErrorKind::GitError => "git repository error",
     }
 }
 

--- a/libimagstore/src/lib.rs
+++ b/libimagstore/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate version;
 extern crate fs2;
+extern crate git2;
 extern crate glob;
 extern crate regex;
 extern crate toml;


### PR DESCRIPTION
Targets #108 

@TheNeikos How can I now implement CRUD-git actions? I mean... I'm rather sure git actions should not go to the `impl Store{}` but to some internal sub types, am I right?

Also, as @neithernut suggested, we may not want to make the git operations default (though I'd vote for enabling git by default). For now I will implement this without an on/off switch. 