### PR TITLE
Add ismatch!() macro

### DIFF
--- a/libimagutil/src/ismatch.rs
+++ b/libimagutil/src/ismatch.rs
@@ -1,0 +1,23 @@
+#[macro_export]
+macro_rules! is_match {
+    ($expression: expr, $($pattern:tt)+) => {
+        is_match! {tt
+            match $expression {
+                $($pattern)+ => true,
+                _            => false
+            }
+        }
+    };
+    (tt $value:expr) => ($value);
+}
+
+#[test]
+fn test_matching() {
+    let foo = Some("-12");
+    assert!(is_match!(foo, Some(bar) if
+        is_match!(bar.as_bytes()[0], b'+' | b'-') &&
+        is_match!(bar.as_bytes()[1], b'0'...b'9')
+    ));
+    assert!(!is_match!(foo, None));
+}
+

--- a/libimagutil/src/lib.rs
+++ b/libimagutil/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use] extern crate log;
 extern crate regex;
 
+pub mod ismatch;
 pub mod key_value_split;
 pub mod trace;
 pub mod variants;


### PR DESCRIPTION
@TheNeikos proves you wrong.

This adds a `is_match!()` macro, to condense this:

```rust
if match x { FooBar(_) => { true }, _ => { false } } {
    // ...
}
// or even
if foo.all(|x| match x { Some(FooBar(_)) => { true }, _ => false }) {
   // ...
}
```

down to

```rust
if is_match!(x, FooBar(_))
    // ...
}
// or 
if foo.all(|x| is_match!(x, Some(FooBar(_)))) {
    // ...
}
```