### PR TITLE
doc: Remove file for "libimagmodule", as this was removed

### DIFF
--- a/doc/src/05000-lib-module.md
+++ b/doc/src/05000-lib-module.md
@@ -1,4 +1,0 @@
-# libmodule {#sec:libmodule}
-
-<!-- Basic common functionality for all modules -->
-


### PR DESCRIPTION
Remove the chapter on "libimagmodule" from the documentation. "libimagmodule" was removed.