### PR TITLE
util: Update regex = 0.1.54

### DIFF
--- a/libimagutil/Cargo.toml
+++ b/libimagutil/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 [dependencies]
 lazy_static = "0.1.15"
 log = "0.3.5"
-regex = "0.1.47"
+regex = "0.1.54"
 


### PR DESCRIPTION
Updates the `regex` crate dependency of `libimagutil` to `0.1.54`.