### PR TITLE
Debug logging to trace logging

### DIFF
--- a/imag-store/src/create.rs
+++ b/imag-store/src/create.rs
@@ -73,7 +73,7 @@ fn create_from_cli_spec(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> R
                 .unwrap_or(String::new())
         });
 
-    debug!("Got content with len = {}", content.len());
+    trace!("Got content with len = {}", content.len());
 
     let header = matches.subcommand_matches("entry")
         .map(|entry_matches| build_toml_header(entry_matches, EntryHeader::new()))
@@ -92,7 +92,7 @@ fn create_from_source(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> Res
         return content.map(|_| ());
     }
     let content = content.unwrap();
-    debug!("Content with len = {}", content.len());
+    trace!("Content with len = {}", content.len());
 
     Entry::from_str(path.clone(), &content[..])
         .map(|mut new_e| {
@@ -119,12 +119,12 @@ fn create_with_content_and_header(rt: &Runtime,
             {
                 let mut e_content = element.get_content_mut();
                 *e_content = content;
-                debug!("New content set");
+                trace!("New content set");
             }
             {
                 let mut e_header  = element.get_header_mut();
                 *e_header = header;
-                debug!("New header set");
+                trace!("New header set");
             }
         })
         .map_err(|e| StoreError::new(StoreErrorKind::BackendError, Some(Box::new(e))))
@@ -133,11 +133,11 @@ fn create_with_content_and_header(rt: &Runtime,
 fn string_from_raw_src(raw_src: &str) -> String {
     let mut content = String::new();
     if raw_src == "-" {
-        debug!("Reading entry from stdin");
+        trace!("Reading entry from stdin");
         let res = stdin().read_to_string(&mut content);
-        debug!("Read {:?} bytes", res);
+        trace!("Read {:?} bytes", res);
     } else {
-        debug!("Reading entry from file at {:?}", raw_src);
+        trace!("Reading entry from file at {:?}", raw_src);
         OpenOptions::new()
             .read(true)
             .write(false)

--- a/imag-store/src/retrieve.rs
+++ b/imag-store/src/retrieve.rs
@@ -15,14 +15,14 @@ pub fn retrieve(rt: &Runtime) {
         .subcommand_matches("retrieve")
         .map(|scmd| {
             let path = scmd.value_of("id").map(|id| build_entry_path(rt, id)).unwrap();
-            debug!("path = {:?}", path);
+            trace!("path = {:?}", path);
             rt.store()
                 // "id" must be present, enforced via clap spec
                 .retrieve(path)
                 .map(|e| print_entry(rt, scmd, e))
                 .map_err(|e| {
                     debug!("No entry.");
-                    debug!("{}", e);
+                    trace!("{}", e);
                 })
 
         });

--- a/imag-store/src/util.rs
+++ b/imag-store/src/util.rs
@@ -21,14 +21,14 @@ pub fn build_entry_path(rt: &Runtime, path_elem: &str) -> PathBuf {
         };
 
         if !contains_version {
-            debug!("Version cannot be parsed inside {:?}", path_elem);
+            trace!("Version cannot be parsed inside {:?}", path_elem);
             warn!("Path does not contain version. Will panic now!");
             panic!("No version in path");
         }
     }
     debug!("Version checking succeeded");
 
-    debug!("Building path from {:?}", path_elem);
+    trace!("Building path from {:?}", path_elem);
     let mut path = rt.store().path().clone();
 
     if path_elem.chars().next() == Some('/') {
@@ -46,14 +46,14 @@ pub fn build_toml_header(matches: &ArgMatches, mut header: EntryHeader) -> Entry
         let mut main = header.into();
         let kvs = headerspecs.into_iter()
                             .filter_map(|hs| {
-                                debug!("- Processing: '{}'", hs);
+                                trace!("- Processing: '{}'", hs);
                                 let kv = String::from(hs).into_kv();
-                                debug!("-        got: '{:?}'", kv);
+                                trace!("-        got: '{:?}'", kv);
                                 kv
                             });
         for tpl in kvs {
             let (key, value) = tpl.into();
-            debug!("Splitting: {:?}", key);
+            trace!("Splitting: {:?}", key);
             let mut split = key.split(".");
             let current = split.next();
             if current.is_some() {
@@ -61,10 +61,10 @@ pub fn build_toml_header(matches: &ArgMatches, mut header: EntryHeader) -> Entry
             }
         }
 
-        debug!("Header = {:?}", main);
+        trace!("Header = {:?}", main);
         EntryHeader::from(main)
     } else {
-        debug!("Header = {:?}", header);
+        trace!("Header = {:?}", header);
         header
     }
 }
@@ -76,10 +76,10 @@ fn insert_key_into(current: String,
     let next = rest_path.next();
 
     if next.is_none() {
-        debug!("Inserting into {:?} = {:?}", current, value);
+        trace!("Inserting into {:?} = {:?}", current, value);
         map.insert(current, parse_value(value));
     } else {
-        debug!("Inserting into {:?} ... = {:?}", current, value);
+        trace!("Inserting into {:?} ... = {:?}", current, value);
         if map.contains_key(&current) {
             match map.get_mut(&current).unwrap() {
                 &mut Value::Table(ref mut t) => {
@@ -90,7 +90,7 @@ fn insert_key_into(current: String,
         } else {
             let mut submap = BTreeMap::new();
             insert_key_into(String::from(next.unwrap()), rest_path, value, &mut submap);
-            debug!("Inserting submap = {:?}", submap);
+            trace!("Inserting submap = {:?}", submap);
             map.insert(current, Value::Table(submap));
         }
     }
@@ -104,29 +104,29 @@ fn parse_value(value: String) -> Value {
     }
 
     if value == "true" {
-        debug!("Building Boolean out of: {:?}...", value);
+        trace!("Building Boolean out of: {:?}...", value);
         Value::Boolean(true)
     } else if value == "false" {
-        debug!("Building Boolean out of: {:?}...", value);
+        trace!("Building Boolean out of: {:?}...", value);
         Value::Boolean(false)
     } else if is_ary(&value) {
-        debug!("Building Array out of: {:?}...", value);
+        trace!("Building Array out of: {:?}...", value);
         let sub = &value[1..(value.len()-1)];
         Value::Array(sub.split(",").map(|v| parse_value(String::from(v))).collect())
     } else {
         FromStr::from_str(&value[..])
             .map(|i: i64| {
-                debug!("Building Integer out of: {:?}...", value);
+                trace!("Building Integer out of: {:?}...", value);
                 Value::Integer(i)
             })
             .unwrap_or_else(|_| {
                 FromStr::from_str(&value[..])
                     .map(|f: f64| {
-                        debug!("Building Float out of: {:?}...", value);
+                        trace!("Building Float out of: {:?}...", value);
                         Value::Float(f)
                     })
                     .unwrap_or_else(|_| {
-                        debug!("Building String out of: {:?}...", value);
+                        trace!("Building String out of: {:?}...", value);
                         Value::String(value)
                     })
             })

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -137,10 +137,10 @@ impl Configuration {
             let editor      = cfg.lookup_str("editor").map(String::from);
             let editor_opts = String::from(cfg.lookup_str("editor-opts").unwrap_or(""));
 
-            debug!("Building configuration");
-            debug!("  - verbosity  : {:?}", verbosity);
-            debug!("  - editor     : {:?}", editor);
-            debug!("  - editor-opts: {}", editor_opts);
+            trace!("Building configuration");
+            trace!("  - verbosity  : {:?}", verbosity);
+            trace!("  - editor     : {:?}", editor);
+            trace!("  - editor-opts: {}", editor_opts);
 
             Configuration {
                 verbosity: verbosity,

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -505,14 +505,14 @@ impl EntryHeader {
             return Err(tokens.err().unwrap());
         }
         let tokens = tokens.unwrap();
-        debug!("tokens = {:?}", tokens);
+        trace!("tokens = {:?}", tokens);
 
         let destination = tokens.iter().last();
         if destination.is_none() {
             return Err(StoreError::new(StoreErrorKind::HeaderPathSyntaxError, None));
         }
         let destination = destination.unwrap();
-        debug!("destination = {:?}", destination);
+        trace!("destination = {:?}", destination);
 
         let path_to_dest = tokens[..(tokens.len() - 1)].into(); // N - 1 tokens
         let mut value = EntryHeader::walk_header(&mut self.header, path_to_dest); // walk N-1 tokens
@@ -520,7 +520,7 @@ impl EntryHeader {
             return Err(value.err().unwrap());
         }
         let mut value = value.unwrap();
-        debug!("walked value = {:?}", value);
+        trace!("walked value = {:?}", value);
 
         match destination {
             &Token::Key(ref s) => { // if the destination shall be an map key->value
@@ -529,7 +529,7 @@ impl EntryHeader {
                      * Put it in there if we have a map
                      */
                     &mut Value::Table(ref mut t) => {
-                        debug!("Matched Key->Table");
+                        trace!("Matched Key->Table");
                         return Ok(t.insert(s.clone(), v));
                     }
 
@@ -537,7 +537,7 @@ impl EntryHeader {
                      * Fail if there is no map here
                      */
                     _ => {
-                        debug!("Matched Key->NON-Table");
+                        trace!("Matched Key->NON-Table");
                         return Err(StoreError::new(StoreErrorKind::HeaderPathTypeFailure, None));
                     }
                 }
@@ -550,17 +550,17 @@ impl EntryHeader {
                      * Put it in there if we have an array
                      */
                     &mut Value::Array(ref mut a) => {
-                        debug!("Matched Index->Array");
+                        trace!("Matched Index->Array");
                         a.push(v); // push to the end of the array
 
                         // if the index is inside the array, we swap-remove the element at this
                         // index
                         if a.len() > i {
-                            debug!("Swap-Removing in Array {:?}[{:?}] <- {:?}", a, i, a[a.len()-1]);
+                            trace!("Swap-Removing in Array {:?}[{:?}] <- {:?}", a, i, a[a.len()-1]);
                             return Ok(Some(a.swap_remove(i)));
                         }
 
-                        debug!("Appended");
+                        trace!("Appended");
                         return Ok(None);
                     },
 
@@ -568,7 +568,7 @@ impl EntryHeader {
                      * Fail if there is no array here
                      */
                     _ => {
-                        debug!("Matched Index->NON-Array");
+                        trace!("Matched Index->NON-Array");
                         return Err(StoreError::new(StoreErrorKind::HeaderPathTypeFailure, None));
                     },
                 }
@@ -639,7 +639,7 @@ impl EntryHeader {
             return Err(StoreError::new(StoreErrorKind::HeaderPathSyntaxError, None));
         }
         let destination = destination.unwrap();
-        debug!("destination = {:?}", destination);
+        trace!("destination = {:?}", destination);
 
         let path_to_dest = tokens[..(tokens.len() - 1)].into(); // N - 1 tokens
         let mut value = EntryHeader::walk_header(&mut self.header, path_to_dest); // walk N-1 tokens
@@ -647,17 +647,17 @@ impl EntryHeader {
             return Err(value.err().unwrap());
         }
         let mut value = value.unwrap();
-        debug!("walked value = {:?}", value);
+        trace!("walked value = {:?}", value);
 
         match destination {
             &Token::Key(ref s) => { // if the destination shall be an map key->value
                 match value {
                     &mut Value::Table(ref mut t) => {
-                        debug!("Matched Key->Table, removing {:?}", s);
+                        trace!("Matched Key->Table, removing {:?}", s);
                         return Ok(t.remove(s));
                     },
                     _ => {
-                        debug!("Matched Key->NON-Table");
+                        trace!("Matched Key->NON-Table");
                         return Err(StoreError::new(StoreErrorKind::HeaderPathTypeFailure, None));
                     }
                 }
@@ -669,14 +669,14 @@ impl EntryHeader {
                         // if the index is inside the array, we swap-remove the element at this
                         // index
                         if a.len() > i {
-                            debug!("Removing in Array {:?}[{:?}]", a, i);
+                            trace!("Removing in Array {:?}[{:?}]", a, i);
                             return Ok(Some(a.remove(i)));
                         } else {
                             return Ok(None);
                         }
                     },
                     _ => {
-                        debug!("Matched Index->NON-Array");
+                        trace!("Matched Index->NON-Array");
                         return Err(StoreError::new(StoreErrorKind::HeaderPathTypeFailure, None));
                     },
                 }


### PR DESCRIPTION
Moves some `debug!()` log output to `trace!()` level.

My policy on this is: If you print variables in the log output, it might be a good idea to `trace!()` instead of `debug!()`. `debug!()` should be done for _what is done_ and `trace!()` for _what data is used_.

Feel free to argue on the single diffs.