### PR TITLE
EntryHeader: Function to get toml object

### DIFF
--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -351,6 +351,10 @@ impl EntryHeader {
         }
     }
 
+    pub fn header(&self) -> &Value {
+        &self.header
+    }
+
     fn from_table(t: Table) -> EntryHeader {
         EntryHeader {
             header: Value::Table(t)


### PR DESCRIPTION
Add function to get the inner toml object from an `EntryHeader`.

Ready for review here.