### PR TITLE
libimagstore: Update glob 0.2.10 -> 0.2.11

### DIFF
--- a/libimagstore/Cargo.toml
+++ b/libimagstore/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 [dependencies]
 fs2 = "0.2.2"
-glob = "0.2.10"
+glob = "0.2.11"
 lazy_static = "0.1.15"
 log = "0.3.5"
 regex = "0.1.54"


### PR DESCRIPTION
Update the `glob` dependency from `0.2.10` to `0.2.11`, which brings us some bug-fixes and implements `Error` on `PatternError`, which will help us in some other PRs with smaller issues.

---

Closes #234 