### PR TITLE
Libimagrt/warning to error

### DIFF
--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -8,7 +8,7 @@ use toml::{Parser, Value};
  */
 pub mod error {
     use std::error::Error;
-    use std::fmt::{Debug, Display, Formatter};
+    use std::fmt::{Display, Formatter};
     use std::fmt::Error as FmtError;
 
     /**

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -235,7 +235,7 @@ fn fetch_config(rtp: &PathBuf) -> Result<Value> {
                 if f.is_err() {
                 }
                 let mut f = f.unwrap();
-                f.read_to_string(&mut s);
+                f.read_to_string(&mut s).ok();
                 s
             };
             Parser::new(&content[..]).parse()

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -231,7 +231,7 @@ fn fetch_config(rtp: &PathBuf) -> Result<Value> {
         .map(|path| {
             let content = {
                 let mut s = String::new();
-                let mut f = File::open(path);
+                let f = File::open(path);
                 if f.is_err() {
                 }
                 let mut f = f.unwrap();

--- a/libimagrt/src/edit.rs
+++ b/libimagrt/src/edit.rs
@@ -41,8 +41,7 @@ pub fn edit_in_tmpfile(rt: &Runtime, s: &mut String) -> EditResult<()> {
     let file_path = file.path();
     let mut file  = try!(file.reopen());
 
-    file.write_all(&s.clone().into_bytes()[..]);
-
+    try!(file.write_all(&s.clone().into_bytes()[..]));
     try!(file.sync_data());
 
     if let Some(mut editor) = rt.editor() {

--- a/libimagrt/src/lib.rs
+++ b/libimagrt/src/lib.rs
@@ -1,3 +1,17 @@
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate log;
 #[macro_use] extern crate itertools;
 #[cfg(unix)] extern crate xdg_basedir;

--- a/libimagrt/src/logger.rs
+++ b/libimagrt/src/logger.rs
@@ -26,7 +26,7 @@ impl Log for ImagLogger {
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {
             // TODO: This is just simple logging. Maybe we can enhance this lateron
-            writeln!(stderr(), "[imag][{: <5}]: {}", record.level(), record.args());
+            writeln!(stderr(), "[imag][{: <5}]: {}", record.level(), record.args()).ok();
         }
     }
 }


### PR DESCRIPTION
Enables some compiler warning-as-error flags after fixing some warnings.