### PR TITLE
Move logger initialization to earliest possible point

### DIFF
--- a/imag-counter/src/main.rs
+++ b/imag-counter/src/main.rs
@@ -49,8 +49,6 @@ fn main() {
         }
     };
 
-    rt.init_logger();
-
     debug!("Hello. Logging was just enabled");
     debug!("I already set up the Runtime object and build the commandline interface parser.");
     debug!("Lets get rollin' ...");

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -40,8 +40,6 @@ fn main() {
         }
     };
 
-    rt.init_logger();
-
     debug!("Hello. Logging was just enabled");
     debug!("I already set up the Runtime object and build the commandline interface parser.");
     debug!("Lets get rollin' ...");

--- a/imag-store/src/main.rs
+++ b/imag-store/src/main.rs
@@ -41,8 +41,6 @@ fn main() {
         }
     };
 
-    rt.init_logger();
-
     debug!("Hello. Logging was just enabled");
     debug!("I already set up the Runtime object and build the commandline interface parser.");
     debug!("Lets get rollin' ...");

--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -37,8 +37,6 @@ fn main() {
         }
     };
 
-    rt.init_logger();
-
     debug!("Hello. Logging was just enabled");
     debug!("I already set up the Runtime object and build the commandline interface parser.");
     debug!("Lets get rollin' ...");

--- a/imag-view/src/main.rs
+++ b/imag-view/src/main.rs
@@ -45,8 +45,6 @@ fn main() {
         }
     };
 
-    rt.init_logger();
-
     debug!("Hello. Logging was just enabled");
     debug!("I already set up the Runtime object and build the commandline interface parser.");
     debug!("Lets get rollin' ...");

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -39,6 +39,12 @@ impl<'a> Runtime<'a> {
         use configuration::error::ConfigErrorKind;
 
         let matches = cli_spec.get_matches();
+
+        let is_debugging = matches.is_present("debugging");
+        let is_verbose   = matches.is_present("verbosity");
+
+        Runtime::init_logger(is_debugging, is_verbose);
+
         let rtp : PathBuf = matches.value_of("runtimepath")
             .map(PathBuf::from)
             .unwrap_or_else(|| {
@@ -153,10 +159,10 @@ impl<'a> Runtime<'a> {
     /**
      * Initialize the internal logger
      */
-    pub fn init_logger(&self) {
-        let lvl = if self.is_debugging() {
+    fn init_logger(is_debugging: bool, is_verbose: bool) {
+        let lvl = if is_debugging {
             LogLevelFilter::Debug
-        } else if self.is_verbose() {
+        } else if is_verbose {
             LogLevelFilter::Info
         } else {
             LogLevelFilter::Error


### PR DESCRIPTION
Closes #280 

The code which was run _before_ the logger init was getting too complex. We need logging there. Therefor I'm changing this to happen implicitely on runtime setup.