### PR TITLE
impl Deref for Note

### DIFF
--- a/libimagnotes/src/note.rs
+++ b/libimagnotes/src/note.rs
@@ -161,6 +161,16 @@ impl<'a> FromStoreId for Note<'a> {
 
 }
 
+impl<'a> Deref for Note<'a> {
+
+    type Target = FileLockEntry<'a>;
+
+    fn deref(&self) -> &FileLockEntry<'a> {
+        &self.entry
+    }
+
+}
+
 pub struct NoteIterator<'a> {
     store: &'a Store,
     iditer: StoreIdIterator,


### PR DESCRIPTION
We might want to `Deref` a `Note` to get the underlying `FileLockEntry`.

(This was extracted from another PR I'm working on)