### PR TITLE
Remove typedef for StoreId type

### DIFF
--- a/libimagentrylist/src/listers/path.rs
+++ b/libimagentrylist/src/listers/path.rs
@@ -32,7 +32,7 @@ impl Lister for PathLister {
                     if self.absolute {
                         pb.canonicalize().map_err(|e| LE::new(LEK::FormatError, Some(Box::new(e))))
                     } else {
-                        Ok(pb)
+                        Ok(pb.into())
                     }
                 })
                 .and_then(|pb| {

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -23,7 +23,7 @@ use glob::glob;
 
 use error::{ParserErrorKind, ParserError};
 use error::{StoreError, StoreErrorKind};
-use storeid::{StoreId, StoreIdIterator};
+use storeid::{IntoStoreId, StoreId, StoreIdIterator};
 use lazyfile::LazyFile;
 
 use hook::aspect::Aspect;
@@ -245,8 +245,8 @@ impl Store {
     }
 
     /// Creates the Entry at the given location (inside the entry)
-    pub fn create<'a>(&'a self, id: StoreId) -> Result<FileLockEntry<'a>> {
-        let id = self.storify_id(id);
+    pub fn create<'a, S: IntoStoreId>(&'a self, id: S) -> Result<FileLockEntry<'a>> {
+        let id = self.storify_id(id.into_storeid());
         if let Err(e) = self.execute_hooks_for_id(self.pre_create_aspects.clone(), &id) {
             return Err(e);
         }
@@ -273,8 +273,8 @@ impl Store {
 
     /// Borrow a given Entry. When the `FileLockEntry` is either `update`d or
     /// dropped, the new Entry is written to disk
-    pub fn retrieve<'a>(&'a self, id: StoreId) -> Result<FileLockEntry<'a>> {
-        let id = self.storify_id(id);
+    pub fn retrieve<'a, S: IntoStoreId>(&'a self, id: S) -> Result<FileLockEntry<'a>> {
+        let id = self.storify_id(id.into_storeid());
         if let Err(e) = self.execute_hooks_for_id(self.pre_retrieve_aspects.clone(), &id) {
             return Err(e);
         }
@@ -356,8 +356,8 @@ impl Store {
 
     /// Retrieve a copy of a given entry, this cannot be used to mutate
     /// the one on disk
-    pub fn retrieve_copy(&self, id: StoreId) -> Result<Entry> {
-        let id = self.storify_id(id);
+    pub fn retrieve_copy<S: IntoStoreId>(&self, id: S) -> Result<Entry> {
+        let id = self.storify_id(id.into_storeid());
         let entries_lock = self.entries.write();
         if entries_lock.is_err() {
             return Err(StoreError::new(StoreErrorKind::LockPoisoned, None))
@@ -374,8 +374,8 @@ impl Store {
     }
 
     /// Delete an entry
-    pub fn delete(&self, id: StoreId) -> Result<()> {
-        let id = self.storify_id(id);
+    pub fn delete<S: IntoStoreId>(&self, id: S) -> Result<()> {
+        let id = self.storify_id(id.into_storeid());
         if let Err(e) = self.execute_hooks_for_id(self.pre_delete_aspects.clone(), &id) {
             return Err(e);
         }

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -57,7 +57,7 @@ impl StoreEntry {
     fn new(id: StoreId) -> StoreEntry {
         StoreEntry {
             id: id.clone(),
-            file: LazyFile::Absent(id),
+            file: LazyFile::Absent(id.into()),
             status: StoreEntryStatus::Present,
         }
     }
@@ -241,7 +241,7 @@ impl Store {
         let mut new_id = self.location.clone();
         new_id.push(id);
         debug!("Created: '{:?}'", new_id);
-        new_id
+        StoreId::from(new_id)
     }
 
     /// Creates the Entry at the given location (inside the entry)

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1119,7 +1119,7 @@ impl Entry {
         }
     }
 
-    pub fn from_file(loc: StoreId, file: &mut File) -> Result<Entry> {
+    pub fn from_file<S: IntoStoreId>(loc: S, file: &mut File) -> Result<Entry> {
         let text = {
             use std::io::Read;
             let mut s = String::new();
@@ -1129,7 +1129,7 @@ impl Entry {
         Self::from_str(loc, &text[..])
     }
 
-    pub fn from_str(loc: StoreId, s: &str) -> Result<Entry> {
+    pub fn from_str<S: IntoStoreId>(loc: S, s: &str) -> Result<Entry> {
         debug!("Building entry from string");
         lazy_static! {
             static ref RE: Regex = Regex::new(r"(?smx)
@@ -1157,7 +1157,7 @@ impl Entry {
 
         debug!("Header and content found. Yay! Building Entry object now");
         Ok(Entry {
-            location: loc,
+            location: loc.into_storeid(),
             header: try!(EntryHeader::parse(header.unwrap())),
             content: content.into(),
         })

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -1,4 +1,7 @@
 use std::path::PathBuf;
+use std::path::Path;
+use std::borrow::Borrow;
+
 use glob::Paths;
 use semver::Version;
 use std::fmt::{Debug, Formatter};
@@ -10,7 +13,48 @@ use store::Result;
 use store::Store;
 
 /// The Index into the Store
-pub type StoreId = PathBuf;
+#[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
+pub struct StoreId(PathBuf);
+
+impl Into<PathBuf> for StoreId {
+
+    fn into(self) -> PathBuf {
+        self.0
+    }
+
+}
+
+impl From<PathBuf> for StoreId {
+
+    fn from(pb: PathBuf) -> StoreId {
+        StoreId(pb)
+    }
+
+}
+
+impl From<String> for StoreId {
+
+    fn from(string: String) -> StoreId {
+        StoreId(string.into())
+    }
+
+}
+
+impl AsRef<Path> for StoreId {
+
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+
+}
+
+impl Borrow<Path> for StoreId {
+
+    fn borrow(&self) -> &Path {
+        self.0.borrow()
+    }
+
+}
 
 /// This Trait allows you to convert various representations to a single one
 /// suitable for usage in the Store

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -116,6 +116,8 @@ macro_rules! module_entry_path_mod {
             use std::path::Path;
             use std::path::PathBuf;
 
+            use $crate::storeid::StoreId;
+
             /// A Struct giving you the ability to choose store entries assigned
             /// to it.
             ///
@@ -140,7 +142,7 @@ macro_rules! module_entry_path_mod {
 
             impl $crate::storeid::IntoStoreId for ModuleEntryPath {
                 fn into_storeid(self) -> $crate::storeid::StoreId {
-                    self.0
+                    StoreId::from(self.0)
                 }
             }
         }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::path::Path;
 use std::borrow::Borrow;
+use std::ops::Deref;
 
 use glob::Paths;
 use semver::Version;
@@ -20,6 +21,15 @@ impl Into<PathBuf> for StoreId {
 
     fn into(self) -> PathBuf {
         self.0
+    }
+
+}
+
+impl Deref for StoreId {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &PathBuf {
+        &self.0
     }
 
 }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -64,7 +64,7 @@ pub trait IntoStoreId {
 
 impl IntoStoreId for PathBuf {
     fn into_storeid(self) -> StoreId {
-        self
+        StoreId(self)
     }
 }
 
@@ -163,7 +163,7 @@ impl Iterator for StoreIdIterator {
     type Item = StoreId;
 
     fn next(&mut self) -> Option<StoreId> {
-        self.paths.next().and_then(|o| o.ok())
+        self.paths.next().and_then(|o| o.ok()).map(|p| StoreId::from(p))
     }
 
 }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -78,6 +78,12 @@ impl IntoStoreId for PathBuf {
     }
 }
 
+impl IntoStoreId for StoreId {
+    fn into_storeid(self) -> StoreId {
+        self
+    }
+}
+
 pub fn build_entry_path(store: &Store, path_elem: &str) -> Result<PathBuf> {
     debug!("Checking path element for version");
     if path_elem.split("~").last().map(|v| Version::parse(v).is_err()).unwrap_or(false) {


### PR DESCRIPTION
but make it a new type instead.

Also derive and implement as many traits as possible for it, so we keep
backwards compatibility as much as possible.

Anyways, we need to rewrite some code for this.

Suggested-by: Marcel Müller <neikos@neikos.email>
Signed-off-by: Matthias Beyer <mail@beyermatthias.de>

---

@TheNeikos can you come up with code which keeps backwards compatibility to 100%? I don't think so, feel free to surprise me!

---

For the curious: This refactoring would enable us to implement traits on the type elsewhere which would allow us to greatly improve the overall codebase.

It also gives us the possibility to implement functions on the type which then can be used to check certain invariants, for example that the `StoreId` should always be an absolute path but starting from the store root directory rather than from the OS root directory. This would greatly improve and simplify some code I'm currently working on in some other PRs.