### PR TITLE
Rename: kind() to err_type()

### DIFF
--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -44,7 +44,7 @@ pub mod error {
         /**
          * get the Kind of the Error
          */
-        pub fn kind(&self) -> ConfigErrorKind {
+        pub fn err_type(&self) -> ConfigErrorKind {
             self.kind.clone()
         }
 
@@ -52,7 +52,7 @@ pub mod error {
          * Get the string, the ConfigError can be described with
          */
         pub fn as_str(e: &ConfigError) -> &'static str {
-            match e.kind() {
+            match e.err_type() {
                 ConfigErrorKind::NoConfigFileFound   => "No config file found",
             }
         }

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -74,7 +74,7 @@ impl<'a> Runtime<'a> {
         let cfg = Configuration::new(&rtp);
         let cfg = if cfg.is_err() {
             let e = cfg.err().unwrap();
-            if e.kind() != ConfigErrorKind::NoConfigFileFound {
+            if e.err_type() != ConfigErrorKind::NoConfigFileFound {
                 let cause : Option<Box<Error>> = Some(Box::new(e));
                 return Err(RuntimeError::new(RuntimeErrorKind::Instantiate, cause));
             } else {


### PR DESCRIPTION
Rename method to be consistent with other crates.