### PR TITLE
fixed some clippy warnings

### DIFF
--- a/imag-counter/src/create.rs
+++ b/imag-counter/src/create.rs
@@ -17,7 +17,7 @@ pub fn create(rt: &Runtime) {
                 .and_then(|i| FromStr::from_str(i).ok())
                 .unwrap_or(0);
 
-            match Counter::new(rt.store(), String::from(name.clone()), init) {
+            match Counter::new(rt.store(), String::from(name), init) {
                 Err(e) => {
                     warn!("Could not create Counter '{}' with initial value '{}'", name, init);
                     trace_error(&e);

--- a/imag-counter/src/interactive.rs
+++ b/imag-counter/src/interactive.rs
@@ -51,7 +51,7 @@ pub fn interactive(rt: &Runtime) {
             exit(1);
         }
 
-        let cont = if input.len() > 0 {
+        let cont = if !input.is_empty() {
             let increment = match input.chars().next() { Some('-') => false, _ => true };
             input.chars().all(|chr| {
                 match pairs.get_mut(&chr) {
@@ -94,8 +94,8 @@ pub fn interactive(rt: &Runtime) {
 fn has_quit_binding(pairs: &BTreeMap<char, Binding>) -> bool {
     pairs.iter()
         .any(|(_, bind)| {
-            match bind {
-                &Binding::Function(ref name, _) => name == "quit",
+            match *bind {
+                Binding::Function(ref name, _) => name == "quit",
                 _ => false,
             }
         })
@@ -109,8 +109,8 @@ enum Binding<'a> {
 impl<'a> Display for Binding<'a> {
 
     fn fmt(&self, fmt: &mut Formatter) -> RResult<(), Error> {
-        match self {
-            &Binding::Counter(ref c) => {
+        match *self {
+            Binding::Counter(ref c) => {
                 match c.name() {
                     Ok(name) => {
                         try!(write!(fmt, "{}", name));
@@ -122,7 +122,7 @@ impl<'a> Display for Binding<'a> {
                     },
                 }
             },
-            &Binding::Function(ref name, _) => write!(fmt, "{}()", name),
+            Binding::Function(ref name, _) => write!(fmt, "{}()", name),
         }
     }
 

--- a/imag-counter/src/list.rs
+++ b/imag-counter/src/list.rs
@@ -16,13 +16,10 @@ pub fn list(rt: &Runtime) {
 
                         if name.is_err() {
                             trace_error(&name.unwrap_err());
+                        } else if value.is_err() {
+                            trace_error(&value.unwrap_err());
                         } else {
-
-                            if value.is_err() {
-                                trace_error(&value.unwrap_err());
-                            } else {
-                                println!("{} - {}", name.unwrap(), value.unwrap());
-                            }
+                            println!("{} - {}", name.unwrap(), value.unwrap());
                         }
                     })
                     .map_err(|e| trace_error(&e))

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -81,16 +81,14 @@ fn handle_internal_linking(rt: &Runtime) {
 
     if cmd.is_present("list") {
         debug!("List...");
-        for entry in cmd.value_of("list").unwrap().split(",") {
+        for entry in cmd.value_of("list").unwrap().split(',') {
             debug!("Listing for '{}'", entry);
             match get_entry_by_name(rt, entry) {
                 Ok(e) => {
                     e.get_internal_links()
                         .map(|links| {
-                            let mut i = 0;
-                            for link in links.iter().map(|l| l.to_str()).filter_map(|x| x) {
+                            for (i, link) in links.iter().map(|l| l.to_str()).filter_map(|x| x).enumerate() {
                                 println!("{: <3}: {}", i, link);
-                                i += 1;
                             }
                         })
                         .map_err(|e| trace_error(&e))
@@ -275,7 +273,7 @@ fn set_links_for_entry(store: &Store, matches: &ArgMatches, entry: &mut FileLock
         .value_of("links")
         .map(String::from)
         .unwrap()
-        .split(",")
+        .split(',')
         .map(|uri| {
             match Url::parse(uri) {
                 Err(e) => {
@@ -299,10 +297,8 @@ fn set_links_for_entry(store: &Store, matches: &ArgMatches, entry: &mut FileLock
 fn list_links_for_entry(store: &Store, entry: &mut FileLockEntry) {
     let res = entry.get_external_links(store)
         .and_then(|links| {
-            let mut i = 0;
-            for link in links {
+            for (i, link) in links.enumerate() {
                 println!("{: <3}: {}", i, link);
-                i += 1;
             }
             Ok(())
         });

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -297,7 +297,7 @@ fn set_links_for_entry(store: &Store, matches: &ArgMatches, entry: &mut FileLock
 fn list_links_for_entry(store: &Store, entry: &mut FileLockEntry) {
     let res = entry.get_external_links(store)
         .and_then(|links| {
-            for (i, link) in links.enumerate() {
+            for (i, link) in links.iter().enumerate() {
                 println!("{: <3}: {}", i, link);
             }
             Ok(())

--- a/imag-notes/src/main.rs
+++ b/imag-notes/src/main.rs
@@ -60,10 +60,9 @@ fn create(rt: &Runtime) {
         .map_err(|e| trace_error(&e))
         .ok();
 
-    if rt.cli().subcommand_matches("create").unwrap().is_present("edit") {
-        if !edit_entry(rt, name) {
-            exit(1);
-        }
+    if rt.cli().subcommand_matches("create").unwrap().is_present("edit") &&
+            !edit_entry(rt, name) {
+        exit(1);
     }
 }
 

--- a/imag-store/src/create.rs
+++ b/imag-store/src/create.rs
@@ -85,8 +85,8 @@ fn create_from_cli_spec(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> R
 fn create_from_source(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> Result<()> {
     let content = matches
         .value_of("from-raw")
-        .ok_or_else(|| StoreError::new(StoreErrorKind::NoCommandlineCall, None))
-        .map(|raw_src| string_from_raw_src(raw_src));
+        .ok_or(StoreError::new(StoreErrorKind::NoCommandlineCall, None))
+        .map(string_from_raw_src);
 
     if content.is_err() {
         return content.map(|_| ());

--- a/imag-store/src/create.rs
+++ b/imag-store/src/create.rs
@@ -60,30 +60,24 @@ pub fn create(rt: &Runtime) {
 
 fn create_from_cli_spec(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> Result<()> {
     let content = matches.subcommand_matches("entry")
-        .map(|entry_subcommand| {
+        .map_or_else(|| {
+            debug!("Didn't find entry subcommand, getting raw content");
+            matches.value_of("from-raw")
+                .map_or_else(String::new, string_from_raw_src)
+        }, |entry_subcommand| {
             debug!("Found entry subcommand, parsing content");
             entry_subcommand
                 .value_of("content")
-                .map(String::from)
-                .unwrap_or_else(|| {
-                    entry_subcommand
-                        .value_of("content-from")
-                        .map(|src| string_from_raw_src(src))
-                        .unwrap_or(String::new())
-                })
-        })
-        .unwrap_or_else(|| {
-            debug!("Didn't find entry subcommand, getting raw content");
-            matches.value_of("from-raw")
-                .map(|raw_src| string_from_raw_src(raw_src))
-                .unwrap_or(String::new())
+                .map_or_else(|| {
+                    entry_subcommand.value_of("content-from")
+                        .map_or_else(String::new, string_from_raw_src)
+                }, String::from)
         });
-
     debug!("Got content with len = {}", content.len());
 
     let header = matches.subcommand_matches("entry")
-        .map(|entry_matches| build_toml_header(entry_matches, EntryHeader::new()))
-        .unwrap_or(EntryHeader::new());
+        .map_or_else(EntryHeader::new,
+            |entry_matches| build_toml_header(entry_matches, EntryHeader::new()));
 
     create_with_content_and_header(rt, path, content, header)
 }
@@ -91,7 +85,7 @@ fn create_from_cli_spec(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> R
 fn create_from_source(rt: &Runtime, matches: &ArgMatches, path: &PathBuf) -> Result<()> {
     let content = matches
         .value_of("from-raw")
-        .ok_or(StoreError::new(StoreErrorKind::NoCommandlineCall, None))
+        .ok_or_else(|| StoreError::new(StoreErrorKind::NoCommandlineCall, None))
         .map(|raw_src| string_from_raw_src(raw_src));
 
     if content.is_err() {

--- a/imag-store/src/error.rs
+++ b/imag-store/src/error.rs
@@ -3,20 +3,18 @@ use std::fmt::Error as FmtError;
 use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
-/**
- * Kind of store error
- */
 #[derive(Clone, Copy, Debug, PartialEq)]
+/// Kind of store error
 pub enum StoreErrorKind {
     BackendError,
     NoCommandlineCall,
-        // maybe more
+    // maybe more
 }
 
 fn store_error_type_as_str(e: &StoreErrorKind) -> &'static str {
-    match e {
-        &StoreErrorKind::BackendError      => "Backend Error",
-        &StoreErrorKind::NoCommandlineCall => "No commandline call",
+    match *e {
+        StoreErrorKind::BackendError      => "Backend Error",
+        StoreErrorKind::NoCommandlineCall => "No commandline call",
     }
 }
 
@@ -37,9 +35,7 @@ pub struct StoreError {
 
 impl StoreError {
 
-    /**
-     * Build a new StoreError from an StoreErrorKind, optionally with cause
-     */
+    ///Build a new StoreError from an StoreErrorKind, optionally with cause
     pub fn new(errtype: StoreErrorKind, cause: Option<Box<Error>>)
         -> StoreError
         {
@@ -49,11 +45,9 @@ impl StoreError {
             }
         }
 
-    /**
-     * Get the error type of this StoreError
-     */
+    /// Get the error type of this StoreError
     pub fn err_type(&self) -> StoreErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -70,7 +64,7 @@ impl Display for StoreError {
 impl Error for StoreError {
 
     fn description(&self) -> &str {
-        store_error_type_as_str(&self.err_type.clone())
+        store_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -96,8 +96,8 @@ fn alter(rt: &Runtime, id: &str, add: Option<&str>, rem: Option<&str>, set: Opti
 
             set.map(|tags| {
                 info!("Setting tags '{}'", tags);
-                let tags = tags.split(',').map(String::from).collect();
-                if let Err(e) = e.set_tags(tags) {
+                let tags : Vec<_> = tags.split(',').map(String::from).collect();
+                if let Err(e) = e.set_tags(&tags) {
                     trace_error(&e);
                 }
             });

--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -77,8 +77,7 @@ fn alter(rt: &Runtime, id: &str, add: Option<&str>, rem: Option<&str>, set: Opti
         .retrieve(path)
         .map(|mut e| {
             add.map(|tags| {
-                let tags = tags.split(",");
-                for tag in tags {
+                for tag in tags.split(',') {
                     info!("Adding tag '{}'", tag);
                     if let Err(e) = e.add_tag(String::from(tag)) {
                         trace_error(&e);
@@ -87,8 +86,7 @@ fn alter(rt: &Runtime, id: &str, add: Option<&str>, rem: Option<&str>, set: Opti
             });
 
             rem.map(|tags| {
-                let tags = tags.split(",");
-                for tag in tags {
+                for tag in tags.split(',') {
                     info!("Removing tag '{}'", tag);
                     if let Err(e) = e.remove_tag(String::from(tag)) {
                         trace_error(&e);
@@ -98,7 +96,7 @@ fn alter(rt: &Runtime, id: &str, add: Option<&str>, rem: Option<&str>, set: Opti
 
             set.map(|tags| {
                 info!("Setting tags '{}'", tags);
-                let tags = tags.split(",").map(String::from).collect();
+                let tags = tags.split(',').map(String::from).collect();
                 if let Err(e) = e.set_tags(tags) {
                     trace_error(&e);
                 }

--- a/imag-view/src/error.rs
+++ b/imag-view/src/error.rs
@@ -15,11 +15,11 @@ pub enum ViewErrorKind {
 }
 
 fn view_error_type_as_str(e: &ViewErrorKind) -> &'static str {
-    match e {
-        &ViewErrorKind::StoreError => "Store error",
-        &ViewErrorKind::NoVersion => "No version specified",
-        &ViewErrorKind::PatternError => "Error in Pattern",
-        &ViewErrorKind::GlobBuildError => "Could not build glob() Argument",
+    match *e {
+        ViewErrorKind::StoreError => "Store error",
+        ViewErrorKind::NoVersion => "No version specified",
+        ViewErrorKind::PatternError => "Error in Pattern",
+        ViewErrorKind::GlobBuildError => "Could not build glob() Argument",
     }
 }
 
@@ -59,7 +59,7 @@ impl ViewError {
      * Get the error type of this ViewError
      */
     pub fn err_type(&self) -> ViewErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -67,7 +67,7 @@ impl ViewError {
 impl Display for ViewError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", view_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", view_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -76,7 +76,7 @@ impl Display for ViewError {
 impl Error for ViewError {
 
     fn description(&self) -> &str {
-        view_error_type_as_str(&self.err_type.clone())
+        view_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/imag-view/src/error.rs
+++ b/imag-view/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 /**

--- a/imag-view/src/main.rs
+++ b/imag-view/src/main.rs
@@ -129,7 +129,7 @@ fn load_entry<'a>(id: &str,
 
     let version = {
         if version.is_none() {
-            let r = id.split("~").last();
+            let r = id.split('~').last();
             if r.is_none() {
                 warn!("No version");
                 return Err(ViewError::new(ViewErrorKind::NoVersion, None));
@@ -144,7 +144,7 @@ fn load_entry<'a>(id: &str,
     debug!("Building path from {:?} and {:?}", id, version);
     let mut path = rt.store().path().clone();
 
-    if id.chars().next() == Some('/') {
+    if id.starts_with('/') {
         path.push(format!("{}~{}", &id[1..id.len()], version));
     } else {
         path.push(format!("{}~{}", id, version));
@@ -161,7 +161,7 @@ fn view_versions_of(id: &str, rt: &Runtime) -> Result<()> {
 
     let mut path = rt.store().path().clone();
 
-    if id.chars().next() == Some('/') {
+    if id.starts_with('/') {
         path.push(format!("{}~*", &id[1..id.len()]));
     } else {
         path.push(format!("{}~*", id));

--- a/libimagcounter/src/counter.rs
+++ b/libimagcounter/src/counter.rs
@@ -144,12 +144,12 @@ impl<'a> Counter<'a> {
 }
 
 trait FromStoreId {
-    fn from_storeid<'a>(&'a Store, StoreId) -> Result<Counter<'a>>;
+    fn from_storeid(&Store, StoreId) -> Result<Counter>;
 }
 
 impl<'a> FromStoreId for Counter<'a> {
 
-    fn from_storeid<'b>(store: &'b Store, id: StoreId) -> Result<Counter<'b>> {
+    fn from_storeid(store: &Store, id: StoreId) -> Result<Counter> {
         debug!("Loading counter from storeid: '{:?}'", id);
         match store.retrieve(id) {
             Err(e) => Err(CE::new(CEK::StoreReadError, Some(Box::new(e)))),

--- a/libimagcounter/src/error.rs
+++ b/libimagcounter/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 /**
@@ -15,11 +14,11 @@ pub enum CounterErrorKind {
 }
 
 fn counter_error_type_as_str(e: &CounterErrorKind) -> &'static str {
-    match e {
-        &CounterErrorKind::StoreReadError  => "Store read error",
-        &CounterErrorKind::StoreWriteError => "Store write error",
-        &CounterErrorKind::HeaderTypeError => "Header type error",
-        &CounterErrorKind::HeaderFieldMissingError => "Header field missing error",
+    match *e {
+        CounterErrorKind::StoreReadError  => "Store read error",
+        CounterErrorKind::StoreWriteError => "Store write error",
+        CounterErrorKind::HeaderTypeError => "Header type error",
+        CounterErrorKind::HeaderFieldMissingError => "Header field missing error",
     }
 }
 
@@ -59,7 +58,7 @@ impl CounterError {
      * Get the error type of this CounterError
      */
     pub fn err_type(&self) -> CounterErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -67,7 +66,7 @@ impl CounterError {
 impl Display for CounterError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", counter_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", counter_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -76,7 +75,7 @@ impl Display for CounterError {
 impl Error for CounterError {
 
     fn description(&self) -> &str {
-        counter_error_type_as_str(&self.err_type.clone())
+        counter_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagentryfilter/src/builtin/header/field_gt.rs
+++ b/libimagentryfilter/src/builtin/header/field_gt.rs
@@ -14,15 +14,15 @@ struct EqGt {
 impl Predicate for EqGt {
 
     fn evaluate(&self, v: Value) -> bool {
-        match &self.comp {
-            &Value::Integer(i) => {
+        match self.comp {
+            Value::Integer(i) => {
                 match v {
                     Value::Integer(j) => i > j,
                     Value::Float(f) => (i as f64) > f,
                     _ => false,
                 }
             },
-            &Value::Float(f) => {
+            Value::Float(f) => {
                 match v {
                     Value::Integer(i) => f > (i as f64),
                     Value::Float(d) => f > d,

--- a/libimagentryfilter/src/builtin/header/field_isempty.rs
+++ b/libimagentryfilter/src/builtin/header/field_isempty.rs
@@ -27,11 +27,11 @@ impl Filter for FieldIsEmpty {
             .map(|v| {
                 match v {
                     Some(Value::Array(a))   => a.is_empty(),
-                    Some(Value::Boolean(_)) => false,
-                    Some(Value::Float(_))   => false,
-                    Some(Value::Integer(_)) => false,
                     Some(Value::String(s))  => s.is_empty(),
                     Some(Value::Table(t))   => t.is_empty(),
+                    Some(Value::Boolean(_)) |
+                    Some(Value::Float(_))   |
+                    Some(Value::Integer(_)) => false,
                     _                       => true,
                 }
             })

--- a/libimagentryfilter/src/builtin/header/field_istype.rs
+++ b/libimagentryfilter/src/builtin/header/field_istype.rs
@@ -21,11 +21,11 @@ impl Type {
 
     fn matches(&self, v: &Value) -> bool {
         match (self, v) {
-            (&Type::String,  &Value::String(_))  => true,
-            (&Type::Integer, &Value::Integer(_)) => true,
-            (&Type::Float,   &Value::Float(_))   => true,
-            (&Type::Boolean, &Value::Boolean(_)) => true,
-            (&Type::Array,   &Value::Array(_))   => true,
+            (&Type::String,  &Value::String(_))  |
+            (&Type::Integer, &Value::Integer(_)) |
+            (&Type::Float,   &Value::Float(_))   |
+            (&Type::Boolean, &Value::Boolean(_)) |
+            (&Type::Array,   &Value::Array(_))   |
             (&Type::Table,   &Value::Table(_))   => true,
             _                                    => false,
         }

--- a/libimagentryfilter/src/builtin/header/field_lt.rs
+++ b/libimagentryfilter/src/builtin/header/field_lt.rs
@@ -14,15 +14,15 @@ struct EqLt {
 impl Predicate for EqLt {
 
     fn evaluate(&self, v: Value) -> bool {
-        match &self.comp {
-            &Value::Integer(i) => {
+        match self.comp {
+            Value::Integer(i) => {
                 match v {
                     Value::Integer(j) => i < j,
                     Value::Float(f) => (i as f64) < f,
                     _ => false,
                 }
             },
-            &Value::Float(f) => {
+            Value::Float(f) => {
                 match v {
                     Value::Integer(i) => f < (i as f64),
                     Value::Float(d) => f < d,

--- a/libimagentryfilter/src/builtin/header/version/eq.rs
+++ b/libimagentryfilter/src/builtin/header/version/eq.rs
@@ -23,7 +23,7 @@ impl Filter for VersionEq {
         e.get_header()
             .read("imag.version")
             .map(|val| {
-                val.map(|v| {
+                val.map_or(false, |v| {
                     match v {
                         Value::String(s) => {
                             match Version::parse(&s[..]) {
@@ -34,7 +34,6 @@ impl Filter for VersionEq {
                         _ => false,
                     }
                 })
-                .unwrap_or(false)
             })
             .unwrap_or(false)
     }

--- a/libimagentryfilter/src/builtin/header/version/gt.rs
+++ b/libimagentryfilter/src/builtin/header/version/gt.rs
@@ -23,7 +23,7 @@ impl Filter for VersionGt {
         e.get_header()
             .read("imag.version")
             .map(|val| {
-                val.map(|v| {
+                val.map_or(false, |v| {
                     match v {
                         Value::String(s) => {
                             match Version::parse(&s[..]) {
@@ -34,7 +34,6 @@ impl Filter for VersionGt {
                         _ => false,
                     }
                 })
-                .unwrap_or(false)
             })
             .unwrap_or(false)
     }

--- a/libimagentryfilter/src/builtin/header/version/lt.rs
+++ b/libimagentryfilter/src/builtin/header/version/lt.rs
@@ -23,7 +23,7 @@ impl Filter for VersionLt {
         e.get_header()
             .read("imag.version")
             .map(|val| {
-                val.map(|v| {
+                val.map_or(false, |v| {
                     match v {
                         Value::String(s) => {
                             match Version::parse(&s[..]) {
@@ -34,7 +34,6 @@ impl Filter for VersionLt {
                         _ => false,
                     }
                 })
-                .unwrap_or(false)
             })
             .unwrap_or(false)
     }

--- a/libimagentrylink/src/error.rs
+++ b/libimagentrylink/src/error.rs
@@ -15,29 +15,29 @@ pub enum LinkErrorKind {
 }
 
 fn link_error_type_as_str(e: &LinkErrorKind) -> &'static str {
-    match e {
-        &LinkErrorKind::EntryHeaderReadError
+    match *e {
+        LinkErrorKind::EntryHeaderReadError
             => "Error while reading an entry header",
 
-        &LinkErrorKind::EntryHeaderWriteError
+        LinkErrorKind::EntryHeaderWriteError
             => "Error while writing an entry header",
 
-        &LinkErrorKind::ExistingLinkTypeWrong
+        LinkErrorKind::ExistingLinkTypeWrong
             => "Existing link entry has wrong type",
 
-        &LinkErrorKind::LinkTargetDoesNotExist
+        LinkErrorKind::LinkTargetDoesNotExist
             => "Link target does not exist in the store",
 
-        &LinkErrorKind::InternalConversionError
+        LinkErrorKind::InternalConversionError
             => "Error while converting values internally",
 
-        &LinkErrorKind::InvalidUri
+        LinkErrorKind::InvalidUri
             => "URI is not valid",
 
-        &LinkErrorKind::StoreReadError
+        LinkErrorKind::StoreReadError
             => "Store read error",
 
-        &LinkErrorKind::StoreWriteError
+        LinkErrorKind::StoreWriteError
             => "Store write error",
     }
 }

--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -31,7 +31,7 @@ use url::Url;
 use crypto::sha1::Sha1;
 use crypto::digest::Digest;
 
-/// "Link" Type, just an abstraction over FileLockEntry to have some convenience internally.
+/// "Link" Type, just an abstraction over `FileLockEntry` to have some convenience internally.
 struct Link<'a> {
     link: FileLockEntry<'a>
 }
@@ -57,7 +57,7 @@ impl<'a> Link<'a> {
             .map_err(|e| LE::new(LEK::StoreReadError, Some(Box::new(e))))
     }
 
-    /// Get a link Url object from a FileLockEntry, ignore errors.
+    /// Get a link Url object from a `FileLockEntry`, ignore errors.
     fn get_link_uri_from_filelockentry(file: &FileLockEntry<'a>) -> Option<Url> {
         file.get_header()
             .read("imag.content.uri")
@@ -78,7 +78,7 @@ impl<'a> Link<'a> {
         match opt {
             Ok(Some(Value::String(s))) => {
                 Url::parse(&s[..])
-                     .map(|s| Some(s))
+                     .map(Some)
                      .map_err(|e| LE::new(LEK::EntryHeaderReadError, Some(Box::new(e))))
             },
             Ok(None) => Ok(None),
@@ -115,7 +115,7 @@ fn get_external_link_from_file(entry: &FileLockEntry) -> Result<Url> {
         .ok_or(LE::new(LEK::StoreReadError, None))
 }
 
-/// Implement ExternalLinker for Entry, hiding the fact that there is no such thing as an external
+/// Implement `ExternalLinker` for `Entry`, hiding the fact that there is no such thing as an external
 /// link in an entry, but internal links to other entries which serve as external links, as one
 /// entry in the store can only have one external link.
 impl ExternalLinker for Entry {

--- a/libimagentrylink/src/internal.rs
+++ b/libimagentrylink/src/internal.rs
@@ -92,9 +92,9 @@ impl InternalLinker for Entry {
 fn links_into_values(links: Vec<StoreId>) -> Vec<Option<Value>> {
     links
         .into_iter()
-        .map(|s| s.to_str().map(|s| String::from(s)))
+        .map(|s| s.to_str().map(String::from))
         .unique()
-        .map(|elem| elem.map(|s| Value::String(s)))
+        .map(|elem| elem.map(Value::String))
         .sorted_by(|a, b| {
             match (a, b) {
                 (&Some(Value::String(ref a)), &Some(Value::String(ref b))) => Ord::cmp(a, b),
@@ -160,7 +160,7 @@ fn process_rw_result(links: StoreResult<Option<Value>>) -> Result<Vec<Link>> {
         }
     };
 
-    if !links.iter().all(|l| match l { &Value::String(_) => true, _ => false }) {
+    if !links.iter().all(|l| match *l { Value::String(_) => true, _ => false }) {
         debug!("At least one of the Values which were expected in the Array of links is a non-String!");
         debug!("Generating LinkError");
         return Err(LinkError::new(LinkErrorKind::ExistingLinkTypeWrong, None));

--- a/libimagentrylist/src/error.rs
+++ b/libimagentrylist/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 /**
@@ -15,11 +14,11 @@ pub enum ListErrorKind {
 }
 
 fn counter_error_type_as_str(err: &ListErrorKind) -> &'static str{
-    match err {
-        &ListErrorKind::FormatError    => "FormatError",
-        &ListErrorKind::EntryError     => "EntryError",
-        &ListErrorKind::IterationError => "IterationError",
-        &ListErrorKind::CLIError       => "No CLI subcommand for listing entries",
+    match *err {
+        ListErrorKind::FormatError    => "FormatError",
+        ListErrorKind::EntryError     => "EntryError",
+        ListErrorKind::IterationError => "IterationError",
+        ListErrorKind::CLIError       => "No CLI subcommand for listing entries",
     }
 }
 
@@ -57,7 +56,7 @@ impl ListError {
      * Get the error type of this ListError
      */
     pub fn err_type(&self) -> ListErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -65,7 +64,7 @@ impl ListError {
 impl Display for ListError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", counter_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", counter_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -74,7 +73,7 @@ impl Display for ListError {
 impl Error for ListError {
 
     fn description(&self) -> &str {
-        counter_error_type_as_str(&self.err_type.clone())
+        counter_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagentrytag/src/error.rs
+++ b/libimagentrytag/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12,11 +11,11 @@ pub enum TagErrorKind {
 }
 
 fn tag_error_type_as_str(e: &TagErrorKind) -> &'static str {
-    match e {
-        &TagErrorKind::TagTypeError     => "Entry Header Tag Type wrong",
-        &TagErrorKind::HeaderReadError  => "Error while reading entry header",
-        &TagErrorKind::HeaderWriteError => "Error while writing entry header",
-        &TagErrorKind::NotATag          => "String is not a tag",
+    match *e {
+        TagErrorKind::TagTypeError     => "Entry Header Tag Type wrong",
+        TagErrorKind::HeaderReadError  => "Error while reading entry header",
+        TagErrorKind::HeaderWriteError => "Error while writing entry header",
+        TagErrorKind::NotATag          => "String is not a tag",
     }
 }
 
@@ -49,7 +48,7 @@ impl TagError {
 impl Display for TagError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", tag_error_type_as_str(&self.kind.clone())));
+        try!(write!(fmt, "[{}]", tag_error_type_as_str(&self.kind)));
         Ok(())
     }
 
@@ -58,7 +57,7 @@ impl Display for TagError {
 impl Error for TagError {
 
     fn description(&self) -> &str {
-        tag_error_type_as_str(&self.kind.clone())
+        tag_error_type_as_str(&self.kind)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagentrytag/src/exec.rs
+++ b/libimagentrytag/src/exec.rs
@@ -7,22 +7,20 @@ use tagable::*;
 use ui::{get_add_tags, get_remove_tags};
 
 pub fn exec_cli_for_entry(matches: &ArgMatches, entry: &mut FileLockEntry) -> Result<()> {
-    match get_add_tags(matches) {
-        Some(ts) => for t in ts {
+    if let Some(ts) = get_add_tags(matches) {
+        for t in ts {
             if let Err(e) = entry.add_tag(t) {
                 return Err(e);
             }
-        },
-        None => { },
+        }
     }
 
-    match get_remove_tags(matches) {
-        Some(ts) => for t in ts {
+    if let Some(ts) = get_remove_tags(matches) {
+        for t in ts {
             if let Err(e) = entry.remove_tag(t) {
                 return Err(e);
             }
-        },
-        None => { },
+        }
     }
 
     Ok(())

--- a/libimagentrytag/src/tag.rs
+++ b/libimagentrytag/src/tag.rs
@@ -1,1 +1,2 @@
 pub type Tag = String;
+pub type TagSlice<'a> = &'a str;

--- a/libimagentrytag/src/tagable.rs
+++ b/libimagentrytag/src/tagable.rs
@@ -7,7 +7,7 @@ use libimagstore::store::{Entry, EntryHeader, FileLockEntry};
 
 use error::{TagError, TagErrorKind};
 use result::Result;
-use tag::Tag;
+use tag::{Tag, TagSlice};
 use util::is_tag;
 
 use toml::Value;
@@ -15,13 +15,13 @@ use toml::Value;
 pub trait Tagable {
 
     fn get_tags(&self) -> Result<Vec<Tag>>;
-    fn set_tags(&mut self, ts: Vec<Tag>) -> Result<()>;
+    fn set_tags(&mut self, ts: &[Tag]) -> Result<()>;
 
     fn add_tag(&mut self, t: Tag) -> Result<()>;
     fn remove_tag(&mut self, t: Tag) -> Result<()>;
 
-    fn has_tag(&self, t: &Tag) -> Result<bool>;
-    fn has_tags(&self, ts: &Vec<Tag>) -> Result<bool>;
+    fn has_tag(&self, t: TagSlice) -> Result<bool>;
+    fn has_tags(&self, ts: &[Tag]) -> Result<bool>;
 
 }
 
@@ -37,11 +37,11 @@ impl Tagable for EntryHeader {
 
         match tags {
             Some(Value::Array(tags)) => {
-                if !tags.iter().all(|t| match t { &Value::String(_) => true, _ => false }) {
+                if !tags.iter().all(|t| match *t { Value::String(_) => true, _ => false }) {
                     return Err(TagError::new(TagErrorKind::TagTypeError, None));
                 }
-                if tags.iter().any(|t| match t {
-                    &Value::String(ref s) => !is_tag(&s),
+                if tags.iter().any(|t| match *t {
+                    Value::String(ref s) => !is_tag(s),
                     _ => unreachable!()})
                 {
                     return Err(TagError::new(TagErrorKind::NotATag, None));
@@ -62,7 +62,7 @@ impl Tagable for EntryHeader {
         }
     }
 
-    fn set_tags(&mut self, ts: Vec<Tag>) -> Result<()> {
+    fn set_tags(&mut self, ts: &[Tag]) -> Result<()> {
         if ts.iter().any(|tag| !is_tag(tag)) {
             debug!("Not a tag: '{}'", ts.iter().filter(|t| !is_tag(t)).next().unwrap());
             return Err(TagError::new(TagErrorKind::NotATag, None));
@@ -83,7 +83,7 @@ impl Tagable for EntryHeader {
         self.get_tags()
             .map(|mut tags| {
                 tags.push(t);
-                self.set_tags(tags.into_iter().unique().collect())
+                self.set_tags(&tags.into_iter().unique().collect::<Vec<_>>()[..])
             })
             .map(|_| ())
     }
@@ -97,12 +97,12 @@ impl Tagable for EntryHeader {
         self.get_tags()
             .map(|mut tags| {
                 tags.retain(|tag| tag.clone() != t);
-                self.set_tags(tags)
+                self.set_tags(&tags[..])
             })
             .map(|_| ())
     }
 
-    fn has_tag(&self, t: &Tag) -> Result<bool> {
+    fn has_tag(&self, t: TagSlice) -> Result<bool> {
         let tags = self.read("imag.tags");
         if tags.is_err() {
             let kind = TagErrorKind::HeaderReadError;
@@ -110,21 +110,21 @@ impl Tagable for EntryHeader {
         }
         let tags = tags.unwrap();
 
-        if !tags.iter().all(|t| match t { &Value::String(_) => true, _ => false }) {
+        if !tags.iter().all(|t| match *t { Value::String(_) => true, _ => false }) {
             return Err(TagError::new(TagErrorKind::TagTypeError, None));
         }
 
         Ok(tags
            .iter()
            .any(|tag| {
-               match tag {
-                   &Value::String(ref s) => { s == t },
+               match *tag {
+                   Value::String(ref s) => { s == t },
                    _ => unreachable!()
                }
            }))
     }
 
-    fn has_tags(&self, tags: &Vec<Tag>) -> Result<bool> {
+    fn has_tags(&self, tags: &[Tag]) -> Result<bool> {
         let mut result = true;
         for tag in tags {
             let check = self.has_tag(tag);
@@ -147,7 +147,7 @@ impl Tagable for Entry {
         self.get_header().get_tags()
     }
 
-    fn set_tags(&mut self, ts: Vec<Tag>) -> Result<()> {
+    fn set_tags(&mut self, ts: &[Tag]) -> Result<()> {
         self.get_header_mut().set_tags(ts)
     }
 
@@ -159,11 +159,11 @@ impl Tagable for Entry {
         self.get_header_mut().remove_tag(t)
     }
 
-    fn has_tag(&self, t: &Tag) -> Result<bool> {
+    fn has_tag(&self, t: TagSlice) -> Result<bool> {
         self.get_header().has_tag(t)
     }
 
-    fn has_tags(&self, ts: &Vec<Tag>) -> Result<bool> {
+    fn has_tags(&self, ts: &[Tag]) -> Result<bool> {
         self.get_header().has_tags(ts)
     }
 
@@ -175,7 +175,7 @@ impl<'a> Tagable for FileLockEntry<'a> {
         self.deref().get_tags()
     }
 
-    fn set_tags(&mut self, ts: Vec<Tag>) -> Result<()> {
+    fn set_tags(&mut self, ts: &[Tag]) -> Result<()> {
         self.deref_mut().set_tags(ts)
     }
 
@@ -187,11 +187,11 @@ impl<'a> Tagable for FileLockEntry<'a> {
         self.deref_mut().remove_tag(t)
     }
 
-    fn has_tag(&self, t: &Tag) -> Result<bool> {
+    fn has_tag(&self, t: TagSlice) -> Result<bool> {
         self.deref().has_tag(t)
     }
 
-    fn has_tags(&self, ts: &Vec<Tag>) -> Result<bool> {
+    fn has_tags(&self, ts: &[Tag]) -> Result<bool> {
         self.deref().has_tags(ts)
     }
 

--- a/libimagentrytag/src/ui.rs
+++ b/libimagentrytag/src/ui.rs
@@ -2,7 +2,7 @@ use clap::{Arg, ArgMatches, App, SubCommand};
 
 use tag::Tag;
 
-/// Generates a clap::SubCommand to be integrated in the commandline-ui builder for building a
+/// Generates a `clap::SubCommand` to be integrated in the commandline-ui builder for building a
 /// "tags --add foo --remove bar" subcommand to do tagging action.
 pub fn tag_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name(tag_subcommand_name())
@@ -41,7 +41,7 @@ pub fn tag_subcommand_names() -> Vec<&'static str> {
     vec![tag_subcommand_add_arg_name(), tag_subcommand_remove_arg_name()]
 }
 
-/// Generates a clap::Arg which can be integrated into the commandline-ui builder for building a
+/// Generates a `clap::Arg` which can be integrated into the commandline-ui builder for building a
 /// "-t" or "--tags" argument which takes values for tagging actions (add, remove)
 pub fn tag_argument<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(tag_argument_name())
@@ -79,7 +79,7 @@ fn extract_tags(matches: &ArgMatches, specifier: &str, specchar: char) -> Option
             .map(|argmatches| {
                 argmatches
                     .map(String::from)
-                    .filter(|s| s.chars().next() == Some(specchar))
+                    .filter(|s| s.starts_with(specchar))
                     .map(|s| {
                         String::from(s.split_at(1).1)
                     })

--- a/libimagentrytag/src/util.rs
+++ b/libimagentrytag/src/util.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
 
-pub fn is_tag(s: &String) -> bool {
+pub fn is_tag(s: &str) -> bool {
     Regex::new("^[a-zA-Z]([a-zA-Z0-9_-]*)$").unwrap().captures(&s[..]).is_some()
 }

--- a/libimagentrytag/src/util.rs
+++ b/libimagentrytag/src/util.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
 
 pub fn is_tag(s: &str) -> bool {
-    Regex::new("^[a-zA-Z]([a-zA-Z0-9_-]*)$").unwrap().captures(&s[..]).is_some()
+    Regex::new("^[a-zA-Z]([a-zA-Z0-9_-]*)$").unwrap().captures(s).is_some()
 }

--- a/libimagentryview/src/error.rs
+++ b/libimagentryview/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 /**
@@ -52,7 +51,7 @@ impl ViewError {
      * Get the error type of this ViewError
      */
     pub fn err_type(&self) -> ViewErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -60,7 +59,7 @@ impl ViewError {
 impl Display for ViewError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", counter_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", counter_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -69,7 +68,7 @@ impl Display for ViewError {
 impl Error for ViewError {
 
     fn description(&self) -> &str {
-        counter_error_type_as_str(&self.err_type.clone())
+        counter_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimaginteraction/src/ask.rs
+++ b/libimaginteraction/src/ask.rs
@@ -40,13 +40,10 @@ fn ask_bool_<R: BufRead>(s: &str, default: Option<bool>, input: &mut R) -> bool 
             return true
         } else if R_NO.is_match(&s[..]) {
             return false
-        } else {
-            if default.is_some() {
-                return default.unwrap();
-            }
-
-            // else again...
+        } else if default.is_some() {
+            return default.unwrap();
         }
+        // else again...
     }
 }
 
@@ -123,26 +120,24 @@ pub fn ask_string_<R: BufRead>(s: &str,
         let _     = input.read_line(&mut s);
 
         if permit_multiline {
-            if permit_multiline && eof.map(|e| e == s).unwrap_or(false) {
+            if permit_multiline && eof.map_or(false, |e| e == s) {
                 return v.join("\n");
             }
 
-            if permit_empty || v.len() != 0 {
+            if permit_empty || !v.is_empty() {
                 v.push(s);
             }
             print!("{}", prompt);
-        } else {
-            if s.len() == 0 && permit_empty {
-                return s;
-            } else if s.len() == 0 && !permit_empty {
-                if default.is_some() {
-                    return default.unwrap();
-                } else {
-                    continue;
-                }
+        } else if s.is_empty() && permit_empty {
+            return s;
+        } else if s.is_empty() && !permit_empty {
+            if default.is_some() {
+                return default.unwrap();
             } else {
-                return s;
+                continue;
             }
+        } else {
+            return s;
         }
     }
 }

--- a/libimaginteraction/src/error.rs
+++ b/libimaginteraction/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 /**
@@ -12,8 +11,8 @@ pub enum InteractionErrorKind {
 }
 
 fn interaction_error_type_as_str(e: &InteractionErrorKind) -> &'static str {
-    match e {
-        &InteractionErrorKind::Unknown => "Unknown Error",
+    match *e {
+        InteractionErrorKind::Unknown => "Unknown Error",
     }
 }
 
@@ -50,7 +49,7 @@ impl InteractionError {
      * Get the error type of this InteractionError
      */
     pub fn err_type(&self) -> InteractionErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -58,7 +57,7 @@ impl InteractionError {
 impl Display for InteractionError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", interaction_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", interaction_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -67,7 +66,7 @@ impl Display for InteractionError {
 impl Error for InteractionError {
 
     fn description(&self) -> &str {
-        interaction_error_type_as_str(&self.err_type.clone())
+        interaction_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagnotes/src/error.rs
+++ b/libimagnotes/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 
 /**
@@ -16,11 +15,11 @@ pub enum NoteErrorKind {
 }
 
 fn note_error_type_as_str(e: &NoteErrorKind) -> &'static str {
-    match e {
-        &NoteErrorKind::StoreWriteError => "Error writing store",
-        &NoteErrorKind::StoreReadError  => "Error reading store",
-        &NoteErrorKind::HeaderTypeError => "Header type error",
-        &NoteErrorKind::NoteToEntryConversion => "Error converting Note instance to Entry instance",
+    match *e {
+        NoteErrorKind::StoreWriteError => "Error writing store",
+        NoteErrorKind::StoreReadError  => "Error reading store",
+        NoteErrorKind::HeaderTypeError => "Header type error",
+        NoteErrorKind::NoteToEntryConversion => "Error converting Note instance to Entry instance",
     }
 }
 
@@ -58,7 +57,7 @@ impl NoteError {
      * Get the error type of this NoteError
      */
     pub fn err_type(&self) -> NoteErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -66,7 +65,7 @@ impl NoteError {
 impl Display for NoteError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", note_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", note_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -75,7 +74,7 @@ impl Display for NoteError {
 impl Error for NoteError {
 
     fn description(&self) -> &str {
-        note_error_type_as_str(&self.err_type.clone())
+        note_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagnotes/src/note.rs
+++ b/libimagnotes/src/note.rs
@@ -10,7 +10,7 @@ use libimagstore::storeid::StoreId;
 use libimagstore::storeid::StoreIdIterator;
 use libimagstore::store::FileLockEntry;
 use libimagstore::store::Store;
-use libimagentrytag::tag::Tag;
+use libimagentrytag::tag::{Tag, TagSlice};
 use libimagentrytag::tagable::Tagable;
 use libimagentrytag::result::Result as TagResult;
 
@@ -124,7 +124,7 @@ impl<'a> Tagable for Note<'a> {
         self.entry.get_tags()
     }
 
-    fn set_tags(&mut self, ts: Vec<Tag>) -> TagResult<()> {
+    fn set_tags(&mut self, ts: &[Tag]) -> TagResult<()> {
         self.entry.set_tags(ts)
     }
 
@@ -136,23 +136,23 @@ impl<'a> Tagable for Note<'a> {
         self.entry.remove_tag(t)
     }
 
-    fn has_tag(&self, t: &Tag) -> TagResult<bool> {
+    fn has_tag(&self, t: TagSlice) -> TagResult<bool> {
         self.entry.has_tag(t)
     }
 
-    fn has_tags(&self, ts: &Vec<Tag>) -> TagResult<bool> {
+    fn has_tags(&self, ts: &[Tag]) -> TagResult<bool> {
         self.entry.has_tags(ts)
     }
 
 }
 
 trait FromStoreId {
-    fn from_storeid<'a>(&'a Store, StoreId) -> Result<Note<'a>>;
+    fn from_storeid(&Store, StoreId) -> Result<Note>;
 }
 
 impl<'a> FromStoreId for Note<'a> {
 
-    fn from_storeid<'b>(store: &'b Store, id: StoreId) -> Result<Note<'b>> {
+    fn from_storeid(store: &Store, id: StoreId) -> Result<Note> {
         debug!("Loading note from storeid: '{:?}'", id);
         match store.retrieve(id) {
             Err(e)    => Err(NE::new(NEK::StoreReadError, Some(Box::new(e)))),

--- a/libimagrt/src/error.rs
+++ b/libimagrt/src/error.rs
@@ -31,10 +31,10 @@ impl RuntimeError {
 }
 
 fn runtime_error_kind_as_str(e: &RuntimeErrorKind) -> &'static str {
-    match e {
-        &RuntimeErrorKind::Instantiate          => "Could not instantiate",
-        &RuntimeErrorKind::IOError              => "IO Error",
-        &RuntimeErrorKind::ProcessExitFailure   => "Process exited with failure",
+    match *e {
+        RuntimeErrorKind::Instantiate          => "Could not instantiate",
+        RuntimeErrorKind::IOError              => "IO Error",
+        RuntimeErrorKind::ProcessExitFailure   => "Process exited with failure",
     }
 }
 

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -55,22 +55,20 @@ impl<'a> Runtime<'a> {
         Runtime::init_logger(is_debugging, is_verbose);
 
         let rtp : PathBuf = matches.value_of("runtimepath")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| {
+            .map_or_else(|| {
                 env::var("HOME")
                     .map(PathBuf::from)
                     .map(|mut p| { p.push(".imag"); p})
                     .unwrap_or_else(|_| {
                         panic!("You seem to be $HOME-less. Please get a $HOME before using this software. We are sorry for you and hope you have some accommodation anyways.");
                     })
-            });
+            }, PathBuf::from);
         let storepath = matches.value_of("storepath")
-                                .map(PathBuf::from)
-                                .unwrap_or({
+                                .map_or_else(|| {
                                     let mut spath = rtp.clone();
                                     spath.push("store");
                                     spath
-                                });
+                                }, PathBuf::from);
 
         let cfg = Configuration::new(&rtp);
         let cfg = if cfg.is_err() {
@@ -87,9 +85,9 @@ impl<'a> Runtime<'a> {
         };
 
         let store_config = {
-            match &cfg {
-                &Some(ref c) => c.store_config().map(|c| c.clone()),
-                &None => None,
+            match cfg {
+                Some(ref c) => c.store_config().cloned(),
+                None => None,
             }
         };
 
@@ -268,8 +266,8 @@ impl<'a> Runtime<'a> {
             .value_of("editor")
             .map(String::from)
             .or({
-                match &self.configuration {
-                    &Some(ref c) => c.editor().map(|s| s.clone()),
+                match self.configuration {
+                    Some(ref c) => c.editor().cloned(),
                     _ => None,
                 }
             })

--- a/libimagstore/src/error.rs
+++ b/libimagstore/src/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Debug, Display, Formatter};
 use std::fmt;
 use std::convert::From;
@@ -41,35 +40,35 @@ pub enum StoreErrorKind {
 }
 
 fn store_error_type_as_str(e: &StoreErrorKind) -> &'static str {
-    match e {
-        &StoreErrorKind::ConfigurationError => "Store Configuration Error",
-        &StoreErrorKind::FileError       => "File Error",
-        &StoreErrorKind::IdLocked        => "ID locked",
-        &StoreErrorKind::IdNotFound      => "ID not found",
-        &StoreErrorKind::OutOfMemory     => "Out of Memory",
-        &StoreErrorKind::FileNotFound    => "File corresponding to ID not found",
-        &StoreErrorKind::FileNotCreated  => "File corresponding to ID could not be created",
-        &StoreErrorKind::IoError         => "File Error",
-        &StoreErrorKind::StorePathExists => "Store path exists",
-        &StoreErrorKind::StorePathCreate => "Store path create",
-        &StoreErrorKind::LockError       => "Error locking datastructure",
-        &StoreErrorKind::LockPoisoned
+    match *e {
+        StoreErrorKind::ConfigurationError => "Store Configuration Error",
+        StoreErrorKind::FileError       |
+        StoreErrorKind::IoError         => "File Error",
+        StoreErrorKind::IdLocked        => "ID locked",
+        StoreErrorKind::IdNotFound      => "ID not found",
+        StoreErrorKind::OutOfMemory     => "Out of Memory",
+        StoreErrorKind::FileNotFound    => "File corresponding to ID not found",
+        StoreErrorKind::FileNotCreated  => "File corresponding to ID could not be created",
+        StoreErrorKind::StorePathExists |
+        StoreErrorKind::StorePathCreate => "Store path create",
+        StoreErrorKind::LockError       => "Error locking datastructure",
+        StoreErrorKind::LockPoisoned
             => "The internal Store Lock has been poisoned",
-        &StoreErrorKind::EntryAlreadyBorrowed => "Entry is already borrowed",
-        &StoreErrorKind::EntryAlreadyExists   => "Entry already exists",
-        &StoreErrorKind::MalformedEntry => "Entry has invalid formatting, missing header",
-        &StoreErrorKind::HeaderPathSyntaxError => "Syntax error in accessor string",
-        &StoreErrorKind::HeaderPathTypeFailure => "Header has wrong type for path",
-        &StoreErrorKind::HeaderKeyNotFound     => "Header Key not found",
-        &StoreErrorKind::HeaderTypeFailure     => "Header type is wrong",
-        &StoreErrorKind::HookRegisterError     => "Hook register error",
-        &StoreErrorKind::AspectNameNotFoundError => "Aspect name not found",
-        &StoreErrorKind::HookExecutionError    => "Hook execution error",
-        &StoreErrorKind::PreHookExecuteError   => "Pre-Hook execution error",
-        &StoreErrorKind::PostHookExecuteError  => "Post-Hook execution error",
-        &StoreErrorKind::StorePathLacksVersion => "The supplied store path has no version part",
-        &StoreErrorKind::GlobError => "glob() error",
-        &StoreErrorKind::EncodingError => "Encoding error",
+        StoreErrorKind::EntryAlreadyBorrowed => "Entry is already borrowed",
+        StoreErrorKind::EntryAlreadyExists   => "Entry already exists",
+        StoreErrorKind::MalformedEntry => "Entry has invalid formatting, missing header",
+        StoreErrorKind::HeaderPathSyntaxError => "Syntax error in accessor string",
+        StoreErrorKind::HeaderPathTypeFailure => "Header has wrong type for path",
+        StoreErrorKind::HeaderKeyNotFound     => "Header Key not found",
+        StoreErrorKind::HeaderTypeFailure     => "Header type is wrong",
+        StoreErrorKind::HookRegisterError     => "Hook register error",
+        StoreErrorKind::AspectNameNotFoundError => "Aspect name not found",
+        StoreErrorKind::HookExecutionError    => "Hook execution error",
+        StoreErrorKind::PreHookExecuteError   => "Pre-Hook execution error",
+        StoreErrorKind::PostHookExecuteError  => "Post-Hook execution error",
+        StoreErrorKind::StorePathLacksVersion => "The supplied store path has no version part",
+        StoreErrorKind::GlobError             => "glob() error",
+        StoreErrorKind::EncodingError         => "Encoding error",
     }
 }
 
@@ -109,7 +108,7 @@ impl StoreError {
      * Get the error type of this StoreError
      */
     pub fn err_type(&self) -> StoreErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -117,7 +116,7 @@ impl StoreError {
 impl Display for StoreError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", store_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", store_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -126,7 +125,7 @@ impl Display for StoreError {
 impl Error for StoreError {
 
     fn description(&self) -> &str {
-        store_error_type_as_str(&self.err_type.clone())
+        store_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagstore/src/hook/aspect.rs
+++ b/libimagstore/src/hook/aspect.rs
@@ -41,7 +41,7 @@ impl StoreIdAccessor for Aspect {
         use crossbeam;
 
         let accessors : Vec<HDA> = self.hooks.iter().map(|h| h.accessor()).collect();
-        if !accessors.iter().all(|a| match a { &HDA::StoreIdAccess(_)  => true, _ => false }) {
+        if !accessors.iter().all(|a| match *a { HDA::StoreIdAccess(_)  => true, _ => false }) {
             return Err(HE::new(HEK::AccessTypeViolation, None));
         }
 
@@ -50,8 +50,8 @@ impl StoreIdAccessor for Aspect {
             .map(|accessor| {
                 crossbeam::scope(|scope| {
                     scope.spawn(|| {
-                        match accessor {
-                            &HDA::StoreIdAccess(accessor) => accessor.access(id),
+                        match *accessor {
+                            HDA::StoreIdAccess(accessor) => accessor.access(id),
                             _ => unreachable!(),
                         }
                         .map_err(|_| ()) // TODO: We're losing the error cause here
@@ -76,9 +76,9 @@ impl MutableHookDataAccessor for Aspect {
         let accessors : Vec<HDA> = self.hooks.iter().map(|h| h.accessor()).collect();
 
         fn is_file_accessor(a: &HDA) -> bool {
-            match a {
-                &HDA::MutableAccess(_)  => true,
-                &HDA::NonMutableAccess(_)  => true,
+            match *a {
+                HDA::MutableAccess(_)     |
+                HDA::NonMutableAccess(_)  => true,
                 _ => false,
             }
         }
@@ -108,7 +108,7 @@ impl NonMutableHookDataAccessor for Aspect {
         use crossbeam;
 
         let accessors : Vec<HDA> = self.hooks.iter().map(|h| h.accessor()).collect();
-        if !accessors.iter().all(|a| match a { &HDA::NonMutableAccess(_)  => true, _ => false }) {
+        if !accessors.iter().all(|a| match *a { HDA::NonMutableAccess(_)  => true, _ => false }) {
             return Err(HE::new(HEK::AccessTypeViolation, None));
         }
 
@@ -117,8 +117,8 @@ impl NonMutableHookDataAccessor for Aspect {
             .map(|accessor| {
                 crossbeam::scope(|scope| {
                     scope.spawn(|| {
-                        match accessor {
-                            &HDA::NonMutableAccess(accessor) => accessor.access(fle),
+                        match *accessor {
+                            HDA::NonMutableAccess(accessor) => accessor.access(fle),
                             _ => unreachable!(),
                         }
                         .map_err(|_| ()) // TODO: We're losing the error cause here

--- a/libimagstore/src/hook/error.rs
+++ b/libimagstore/src/hook/error.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::Error as FmtError;
-use std::clone::Clone;
 use std::fmt::{Display, Formatter};
 use std::convert::Into;
 
@@ -35,9 +34,9 @@ impl Into<HookError> for (HookErrorKind, Box<Error>) {
 }
 
 fn hook_error_type_as_str(e: &HookErrorKind) -> &'static str {
-    match e {
-        &HookErrorKind::HookExecutionError  => "Hook exec error",
-        &HookErrorKind::AccessTypeViolation => "Hook access type violation",
+    match *e {
+        HookErrorKind::HookExecutionError  => "Hook exec error",
+        HookErrorKind::AccessTypeViolation => "Hook access type violation",
     }
 }
 
@@ -77,7 +76,7 @@ impl HookError {
      * Get the error type of this HookError
      */
     pub fn err_type(&self) -> HookErrorKind {
-        self.err_type.clone()
+        self.err_type
     }
 
 }
@@ -85,7 +84,7 @@ impl HookError {
 impl Display for HookError {
 
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", hook_error_type_as_str(&self.err_type.clone())));
+        try!(write!(fmt, "[{}]", hook_error_type_as_str(&self.err_type)));
         Ok(())
     }
 
@@ -94,7 +93,7 @@ impl Display for HookError {
 impl Error for HookError {
 
     fn description(&self) -> &str {
-        hook_error_type_as_str(&self.err_type.clone())
+        hook_error_type_as_str(&self.err_type)
     }
 
     fn cause(&self) -> Option<&Error> {

--- a/libimagstore/src/lazyfile.rs
+++ b/libimagstore/src/lazyfile.rs
@@ -4,11 +4,9 @@ use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::fs::{File, OpenOptions, create_dir_all};
 
-/**
- * LazyFile type
- *
- * A lazy file is either absent, but a path to it is available, or it is present.
- */
+/// `LazyFile` type
+///
+/// A lazy file is either absent, but a path to it is available, or it is present.
 #[derive(Debug)]
 pub enum LazyFile {
     Absent(PathBuf),

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::collections::BTreeMap;
 use std::io::{Seek, SeekFrom};
-use std::io::Write;
 use std::convert::From;
 use std::convert::Into;
 use std::sync::Mutex;
@@ -30,7 +29,6 @@ use lazyfile::LazyFile;
 
 use hook::aspect::Aspect;
 use hook::accessor::{ MutableHookDataAccessor,
-            NonMutableHookDataAccessor,
             StoreIdAccessor};
 use hook::position::HookPosition;
 use hook::Hook;

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -85,7 +85,7 @@ impl IntoStoreId for StoreId {
 
 pub fn build_entry_path(store: &Store, path_elem: &str) -> Result<PathBuf> {
     debug!("Checking path element for version");
-    if path_elem.split("~").last().map(|v| Version::parse(v).is_err()).unwrap_or(false) {
+    if path_elem.split('~').last().map_or(false, |v| Version::parse(v).is_err()) {
         debug!("Version cannot be parsed from {:?}", path_elem);
         debug!("Path does not contain version!");
         return Err(StoreError::new(StoreErrorKind::StorePathLacksVersion, None));
@@ -95,8 +95,8 @@ pub fn build_entry_path(store: &Store, path_elem: &str) -> Result<PathBuf> {
     debug!("Building path from {:?}", path_elem);
     let mut path = store.path().clone();
 
-    if path_elem.chars().next() == Some('/') {
-        path.push(&path_elem[1..path_elem.len()]);
+    if path_elem.starts_with('/') {
+        path.push(&path_elem[1..]);
     } else {
         path.push(path_elem);
     }

--- a/libimagstorestdhook/src/debug.rs
+++ b/libimagstorestdhook/src/debug.rs
@@ -43,14 +43,14 @@ impl HookDataAccessorProvider for DebugHook {
         use libimagstore::hook::accessor::HookDataAccessor as HDA;
 
         match self.position {
-            HP::PreCreate    => HDA::StoreIdAccess(&self.accessor),
-            HP::PostCreate   => HDA::MutableAccess(&self.accessor),
-            HP::PreRetrieve  => HDA::StoreIdAccess(&self.accessor),
-            HP::PostRetrieve => HDA::MutableAccess(&self.accessor),
-            HP::PreUpdate    => HDA::MutableAccess(&self.accessor),
-            HP::PostUpdate   => HDA::MutableAccess(&self.accessor),
-            HP::PreDelete    => HDA::StoreIdAccess(&self.accessor),
+            HP::PreCreate    |
+            HP::PreRetrieve  |
+            HP::PreDelete    |
             HP::PostDelete   => HDA::StoreIdAccess(&self.accessor),
+            HP::PostCreate   |
+            HP::PostRetrieve |
+            HP::PreUpdate    |
+            HP::PostUpdate   => HDA::MutableAccess(&self.accessor),
         }
     }
 

--- a/libimagstorestdhook/src/flock.rs
+++ b/libimagstorestdhook/src/flock.rs
@@ -51,9 +51,9 @@ pub enum Action {
 }
 
 fn action_to_str(a: &Action) -> &'static str {
-    match a {
-        &Action::Lock   => "lock",
-        &Action::Unlock => "unlock",
+    match *a {
+        Action::Lock   => "lock",
+        Action::Unlock => "unlock",
     }
 }
 

--- a/libimagstorestdhook/src/linkverify.rs
+++ b/libimagstorestdhook/src/linkverify.rs
@@ -57,10 +57,8 @@ impl NonMutableHookDataAccessor for LinkedEntriesExistHook {
                     path.push(link);
                     if !path.exists() {
                         warn!("File link does not exist: {:?} -> {:?}", fle.get_location(), path);
-                    } else {
-                        if !path.is_file() {
-                            warn!("File link is not a file: {:?} -> {:?}", fle.get_location(), path);
-                        }
+                    } else if !path.is_file() {
+                        warn!("File link is not a file: {:?} -> {:?}", fle.get_location(), path);
                     }
                 }
             })

--- a/libimagutil/src/trace.rs
+++ b/libimagutil/src/trace.rs
@@ -59,7 +59,7 @@ fn print_trace_maxdepth(idx: u64, e: &Error, max: u64) -> Option<&Error> {
     e.cause()
 }
 
-/// Count errors in Error::cause() recursively
+/// Count errors in `Error::cause()` recursively
 fn count_error_causes(e: &Error) -> u64 {
     1 + if e.cause().is_some() { count_error_causes(e.cause().unwrap()) } else { 0 }
 }


### PR DESCRIPTION
Those are mostly style nits, but some things may even improve performance (like use of the `Entry` API or `Cow<'a, str>` instead of copying `String`s around).