### PR TITLE
Libimagstore/get

### DIFF
--- a/libimagstore/src/error.rs
+++ b/libimagstore/src/error.rs
@@ -28,7 +28,8 @@ generate_error_types!(StoreError, StoreErrorKind,
     PostHookExecuteError    => "Post-Hook execution error",
     StorePathLacksVersion   => "The supplied store path has no version part",
     GlobError               => "glob() error",
-    EncodingError           => "Encoding error"
+    EncodingError           => "Encoding error",
+    StorePathError          => "Store Path error"
 );
 
 generate_error_types!(ParserError, ParserErrorKind,

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -438,7 +438,8 @@ impl Store {
                 debug!("glob()ing with '{}'", path);
                 glob(&path[..]).map_err(|e| SE::new(SEK::GlobError, Some(Box::new(e))))
             })
-            .map(|paths| StoreIdIterator::new(Box::new(GlobStoreIdIterator::new(paths))))
+            .map(|paths| GlobStoreIdIterator::new(paths).into())
+            .map_err(|e| SE::new(SEK::GlobError, Some(Box::new(e))))
     }
 
     // Walk the store tree for the module
@@ -1299,6 +1300,7 @@ mod glob_store_iter {
     use std::fmt::Error as FmtError;
     use glob::Paths;
     use storeid::StoreId;
+    use storeid::StoreIdIterator;
 
     pub struct GlobStoreIdIterator {
         paths: Paths,
@@ -1308,6 +1310,14 @@ mod glob_store_iter {
 
         fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
             write!(fmt, "GlobStoreIdIterator")
+        }
+
+    }
+
+    impl Into<StoreIdIterator> for GlobStoreIdIterator {
+
+        fn into(self) -> StoreIdIterator {
+            StoreIdIterator::new(Box::new(self))
         }
 
     }

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -387,6 +387,45 @@ impl Store {
         }
     }
 
+    /// Same as `Store::get()` but also tries older versions of the entry, returning an iterator
+    /// over all versions of the entry.
+    pub fn get_all_versions<'a, S: IntoStoreId>(&'a self, id: S) -> Result<StoreIdIterator>
+    {
+        // get PathBuf component from storeid, but not version component
+        fn path_component<S: IntoStoreId>(id: S) -> Result<PathBuf> {
+            let p : PathBuf = id.into_storeid().into();
+            match p.to_str() {
+                Some(s) => {
+                    let mut split       = s.split("~");
+                    let path_element    = match split.next() {
+                        Some(s) => s,
+                        None => return Err(SE::new(SEK::StorePathError, None)),
+                    };
+
+                    Ok(PathBuf::from(path_element))
+                },
+
+                None => Err(SE::new(SEK::StorePathError, None)),
+            }
+        }
+
+        fn build_glob_pattern(mut pb: PathBuf) -> Option<String> {
+            pb.push("~*.*.*");
+            pb.to_str().map(String::from)
+        }
+
+        match path_component(id).map(build_glob_pattern) {
+            Err(e) => Err(SE::new(SEK::StorePathError, Some(Box::new(e)))),
+            Ok(None) => Err(SE::new(SEK::StorePathError, None)),
+            Ok(Some(pattern)) => {
+                glob(&pattern[..])
+                    .map(|paths| GlobStoreIdIterator::new(paths).into())
+                    .map_err(|e| SE::new(SEK::GlobError, Some(Box::new(e))))
+            }
+        }
+
+    }
+
     /// Iterate over all StoreIds for one module name
     pub fn retrieve_for_module(&self, mod_name: &str) -> Result<StoreIdIterator> {
         let mut path = self.path().clone();


### PR DESCRIPTION
Getter for entries in the store.

This targets #294 as we should use implicit fallbacks to older versions, but we must provide an interface to find older versions of entries. This seems to be a good approach for me.

@TheNeikos what do you think?