### PR TITLE
Libimagrt/runtime setup helper

### DIFF
--- a/imag-counter/src/main.rs
+++ b/imag-counter/src/main.rs
@@ -25,7 +25,7 @@ extern crate libimagutil;
 use std::process::exit;
 use std::str::FromStr;
 
-use libimagrt::runtime::Runtime;
+use libimagrt::setup::generate_runtime_setup;
 use libimagcounter::counter::Counter;
 use libimagerror::trace::trace_error;
 use libimagutil::key_value_split::IntoKeyValue;
@@ -50,20 +50,10 @@ enum Action {
 }
 
 fn main() {
-    let name = "imag-counter";
-    let version = &version!()[..];
-    let about = "Counter tool to count things";
-    let ui = build_ui(Runtime::get_default_cli_builder(name, version, about));
-    let rt = {
-        let rt = Runtime::new(ui);
-        if rt.is_ok() {
-            rt.unwrap()
-        } else {
-            println!("Could not set up Runtime");
-            println!("{:?}", rt.unwrap_err());
-            exit(1);
-        }
-    };
+    let rt = generate_runtime_setup("imag-counter",
+                                    &version!()[..],
+                                    "Counter tool to count things",
+                                    build_ui);
 
     rt.cli()
         .subcommand_name()

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -29,6 +29,7 @@ use std::process::exit;
 use std::ops::Deref;
 
 use libimagrt::runtime::Runtime;
+use libimagrt::setup::generate_runtime_setup;
 use libimagstore::error::StoreError;
 use libimagstore::store::Entry;
 use libimagstore::store::FileLockEntry;
@@ -43,20 +44,10 @@ mod ui;
 use ui::build_ui;
 
 fn main() {
-    let name = "imag-link";
-    let version = &version!()[..];
-    let about = "Link entries";
-    let ui = build_ui(Runtime::get_default_cli_builder(name, version, about));
-    let rt = {
-        let rt = Runtime::new(ui);
-        if rt.is_ok() {
-            rt.unwrap()
-        } else {
-            println!("Could not set up Runtime");
-            println!("{:?}", rt.unwrap_err());
-            exit(1);
-        }
-    };
+    let rt = generate_runtime_setup("imag-link",
+                                    &version!()[..],
+                                    "Link entries",
+                                    build_ui);
 
     rt.cli()
         .subcommand_name()

--- a/imag-notes/src/main.rs
+++ b/imag-notes/src/main.rs
@@ -12,6 +12,7 @@ use std::process::exit;
 
 use libimagrt::edit::Edit;
 use libimagrt::runtime::Runtime;
+use libimagrt::setup::generate_runtime_setup;
 use libimagnotes::note::Note;
 use libimagerror::trace::trace_error;
 
@@ -19,20 +20,10 @@ mod ui;
 use ui::build_ui;
 
 fn main() {
-    let name = "imag-notes";
-    let version = &version!()[..];
-    let about = "Note taking helper";
-    let ui = build_ui(Runtime::get_default_cli_builder(name, version, about));
-    let rt = {
-        let rt = Runtime::new(ui);
-        if rt.is_ok() {
-            rt.unwrap()
-        } else {
-            println!("Could not set up Runtime");
-            println!("{:?}", rt.unwrap_err());
-            exit(1);
-        }
-    };
+    let rt = generate_runtime_setup("imag-notes",
+                                    &version!()[..],
+                                    "Note taking helper",
+                                    build_ui);
 
     rt.cli()
         .subcommand_name()

--- a/imag-store/src/main.rs
+++ b/imag-store/src/main.rs
@@ -24,8 +24,7 @@ extern crate libimagstore;
 extern crate libimagutil;
 #[macro_use] extern crate libimagerror;
 
-use libimagrt::runtime::Runtime;
-use std::process::exit;
+use libimagrt::setup::generate_runtime_setup;
 
 mod error;
 mod ui;
@@ -42,20 +41,10 @@ use update::update;
 use delete::delete;
 
 fn main() {
-    let name = "imag-store";
-    let version = &version!()[..];
-    let about = "Direct interface to the store. Use with great care!";
-    let ui = build_ui(Runtime::get_default_cli_builder(name, version, about));
-    let rt = {
-        let rt = Runtime::new(ui);
-        if rt.is_ok() {
-            rt.unwrap()
-        } else {
-            println!("Could not set up Runtime");
-            println!("{:?}", rt.unwrap_err());
-            exit(1);
-        }
-    };
+    let rt = generate_runtime_setup("imag-store",
+                                    &version!()[..],
+                                    "Direct interface to the store. Use with great care!",
+                                    build_ui);
 
     rt.cli()
         .subcommand_name()

--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -12,6 +12,7 @@ extern crate libimagerror;
 use std::process::exit;
 
 use libimagrt::runtime::Runtime;
+use libimagrt::setup::generate_runtime_setup;
 use libimagentrytag::tagable::Tagable;
 use libimagstore::storeid::build_entry_path;
 use libimagerror::trace::trace_error;
@@ -21,20 +22,10 @@ mod ui;
 use ui::build_ui;
 
 fn main() {
-    let name = "imag-store";
-    let version = &version!()[..];
-    let about = "Direct interface to the store. Use with great care!";
-    let ui = build_ui(Runtime::get_default_cli_builder(name, version, about));
-    let rt = {
-        let rt = Runtime::new(ui);
-        if rt.is_ok() {
-            rt.unwrap()
-        } else {
-            println!("Could not set up Runtime");
-            println!("{:?}", rt.unwrap_err());
-            exit(1);
-        }
-    };
+    let rt = generate_runtime_setup("imag-store",
+                                    &version!()[..],
+                                    "Direct interface to the store. Use with great care!",
+                                    build_ui);
 
     let id = rt.cli().value_of("id").unwrap(); // enforced by clap
     rt.cli()

--- a/imag-view/src/main.rs
+++ b/imag-view/src/main.rs
@@ -28,6 +28,7 @@ use std::result::Result as RResult;
 use std::process::exit;
 
 use libimagrt::runtime::Runtime;
+use libimagrt::setup::generate_runtime_setup;
 use libimagstore::store::FileLockEntry;
 use libimagerror::trace::trace_error;
 
@@ -44,20 +45,10 @@ use viewer::stdout::StdoutViewer;
 type Result<T> = RResult<T, ViewError>;
 
 fn main() {
-    let name = "imag-view";
-    let version = &version!()[..];
-    let about = "View entries (readonly)";
-    let ui = build_ui(Runtime::get_default_cli_builder(name, version, about));
-    let rt = {
-        let rt = Runtime::new(ui);
-        if rt.is_ok() {
-            rt.unwrap()
-        } else {
-            println!("Could not set up Runtime");
-            println!("{:?}", rt.unwrap_err());
-            exit(1); // we can afford not-executing destructors here
-        }
-    };
+    let rt = generate_runtime_setup( "imag-view",
+                                     &version!()[..],
+                                     "View entries (readonly)",
+                                     build_ui);
 
     let entry_id = rt.cli().value_of("id").unwrap(); // enforced by clap
 

--- a/libimagrt/src/lib.rs
+++ b/libimagrt/src/lib.rs
@@ -34,4 +34,5 @@ mod logger;
 pub mod edit;
 pub mod error;
 pub mod runtime;
+pub mod setup;
 

--- a/libimagrt/src/setup.rs
+++ b/libimagrt/src/setup.rs
@@ -1,0 +1,27 @@
+use clap::App;
+
+use runtime::Runtime;
+
+pub type Name          = &'static str;
+pub type Version<'a>   = &'a str;
+pub type About         = &'static str;
+
+/// Helper to generate the Runtime object
+///
+/// exit()s the program if the runtime couldn't be build, prints error with println!() before
+/// exiting
+pub fn generate_runtime_setup<'a, B>(name: Name, version: Version<'a>, about: About, builder: B)
+    -> Runtime<'a>
+    where B: FnOnce(App<'a, 'a>) -> App<'a, 'a>
+{
+    use std::process::exit;
+    use libimagerror::trace::trace_error_dbg;
+
+    Runtime::new(builder(Runtime::get_default_cli_builder(name, version, about)))
+        .unwrap_or_else(|e| {
+            println!("Could not set up Runtime");
+            println!("{:?}", e);
+            trace_error_dbg(&e);
+            exit(1);
+        })
+}


### PR DESCRIPTION
Removes the runtime setup boilerplate code and replaces it with a simple helper function from the `libimagrt` crate.