### PR TITLE
Libimagentrytag/more helpers

### DIFF
--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -13,8 +13,10 @@ use std::process::exit;
 
 use libimagrt::runtime::Runtime;
 use libimagentrytag::tagable::Tagable;
+use libimagentrytag::tag::Tag;
 use libimagstore::storeid::build_entry_path;
 use libimagerror::trace::trace_error;
+use libimagentrytag::ui::{get_add_tags, get_remove_tags};
 
 mod ui;
 
@@ -41,9 +43,8 @@ fn main() {
         .subcommand_name()
         .map_or_else(
             || {
-                let add = rt.cli().values_of("add").map(|o| o.map(String::from));
-                let rem = rt.cli().values_of("remove").map(|o| o.map(String::from));
-
+                let add = get_add_tags(rt.cli());
+                let rem = get_remove_tags(rt.cli());
                 alter(&rt, id, add, rem);
             },
             |name| {
@@ -58,7 +59,7 @@ fn main() {
             });
 }
 
-fn alter<SI: Iterator<Item = String>>(rt: &Runtime, id: &str, add: Option<SI>, rem: Option<SI>) {
+fn alter(rt: &Runtime, id: &str, add: Option<Vec<Tag>>, rem: Option<Vec<Tag>>) {
     let path = {
         match build_entry_path(rt.store(), id) {
             Err(e) => {

--- a/imag-tag/src/ui.rs
+++ b/imag-tag/src/ui.rs
@@ -1,5 +1,7 @@
 use clap::{Arg, App, ArgGroup, SubCommand};
 
+use libimagentrytag::ui::{tag_add_arg, tag_remove_arg};
+
 pub fn build_ui<'a>(app: App<'a, 'a>) -> App<'a, 'a> {
     app.arg(Arg::with_name("id")
                 .long("id")
@@ -8,21 +10,8 @@ pub fn build_ui<'a>(app: App<'a, 'a>) -> App<'a, 'a> {
                 .required(true)
                 .help("Use this entry"))
 
-        .arg(Arg::with_name("add")
-             .long("add")
-             .short("a")
-             .takes_value(true)
-             .required(false)
-             .multiple(true)
-             .help("Add this tag"))
-
-        .arg(Arg::with_name("remove")
-             .long("remove")
-             .short("r")
-             .takes_value(true)
-             .required(false)
-             .multiple(true)
-             .help("Remove this tag"))
+        .arg(tag_add_arg())
+        .arg(tag_remove_arg())
 
        .subcommand(SubCommand::with_name("list")
                    .about("List tags (default)")

--- a/libimagentrytag/src/ui.rs
+++ b/libimagentrytag/src/ui.rs
@@ -75,13 +75,9 @@ pub fn get_add_tags(matches: &ArgMatches) -> Option<Vec<Tag>> {
 ///
 /// Returns none if the argument was not specified
 pub fn get_remove_tags(matches: &ArgMatches) -> Option<Vec<Tag>> {
-    if let Some(v) = extract_tags(matches, tag_subcommand_remove_arg_name(), '-') {
-        return Some(v);
-    } else {
-        matches
-            .values_of(tag_subcommand_remove_arg_name())
-            .map(|values| values.map(String::from).collect())
-    }
+    let rem = tag_subcommand_remove_arg_name();
+    extract_tags(matches, rem, '+')
+        .or_else(|| matches.values_of(rem).map(|values| values.map(String::from).collect()))
 }
 
 fn extract_tags(matches: &ArgMatches, specifier: &str, specchar: char) -> Option<Vec<Tag>> {

--- a/libimagentrytag/src/ui.rs
+++ b/libimagentrytag/src/ui.rs
@@ -66,13 +66,9 @@ pub fn tag_argument_name() -> &'static str {
 ///
 /// Returns none if the argument was not specified
 pub fn get_add_tags(matches: &ArgMatches) -> Option<Vec<Tag>> {
-    if let Some(v) = extract_tags(matches, tag_subcommand_add_arg_name(), '+') {
-        return Some(v);
-    } else {
-        matches
-            .values_of(tag_subcommand_add_arg_name())
-            .map(|values| values.map(String::from).collect())
-    }
+    let add = tag_subcommand_add_arg_name();
+    extract_tags(matches, add, '+')
+        .or_else(|| matches.values_of(add).map(|values| values.map(String::from).collect()))
 }
 
 /// Get the tags which should be removed from the commandline

--- a/libimagentrytag/src/ui.rs
+++ b/libimagentrytag/src/ui.rs
@@ -9,20 +9,26 @@ pub fn tag_subcommand<'a, 'b>() -> App<'a, 'b> {
         .author("Matthias Beyer <mail@beyermatthias.de>")
         .version("0.1")
         .about("Add or remove tags")
+        .arg(tag_add_arg())
+        .arg(tag_remove_arg())
+}
 
-        .arg(Arg::with_name(tag_subcommand_add_arg_name())
-             .short("a")
-             .long("add")
-             .takes_value(true)
-             .multiple(true)
-             .help("Add tags, seperated by comma or by specifying multiple times"))
+pub fn tag_add_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(tag_subcommand_add_arg_name())
+        .short("a")
+        .long("add")
+        .takes_value(true)
+        .multiple(true)
+        .help("Add tags, seperated by comma or by specifying multiple times")
+}
 
-        .arg(Arg::with_name(tag_subcommand_remove_arg_name())
-             .short("r")
-             .long("remove")
-             .takes_value(true)
-             .multiple(true)
-             .help("Remove tags, seperated by comma or by specifying multiple times"))
+pub fn tag_remove_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(tag_subcommand_remove_arg_name())
+        .short("r")
+        .long("remove")
+        .takes_value(true)
+        .multiple(true)
+        .help("Remove tags, seperated by comma or by specifying multiple times")
 }
 
 pub fn tag_subcommand_name() -> &'static str {

--- a/libimagentrytag/src/ui.rs
+++ b/libimagentrytag/src/ui.rs
@@ -79,7 +79,13 @@ pub fn get_add_tags(matches: &ArgMatches) -> Option<Vec<Tag>> {
 ///
 /// Returns none if the argument was not specified
 pub fn get_remove_tags(matches: &ArgMatches) -> Option<Vec<Tag>> {
-    extract_tags(matches, "remove-tags", '-')
+    if let Some(v) = extract_tags(matches, tag_subcommand_remove_arg_name(), '-') {
+        return Some(v);
+    } else {
+        matches
+            .values_of(tag_subcommand_remove_arg_name())
+            .map(|values| values.map(String::from).collect())
+    }
 }
 
 fn extract_tags(matches: &ArgMatches, specifier: &str, specchar: char) -> Option<Vec<Tag>> {

--- a/libimagentrytag/src/ui.rs
+++ b/libimagentrytag/src/ui.rs
@@ -66,7 +66,13 @@ pub fn tag_argument_name() -> &'static str {
 ///
 /// Returns none if the argument was not specified
 pub fn get_add_tags(matches: &ArgMatches) -> Option<Vec<Tag>> {
-    extract_tags(matches, "add-tags", '+')
+    if let Some(v) = extract_tags(matches, tag_subcommand_add_arg_name(), '+') {
+        return Some(v);
+    } else {
+        matches
+            .values_of(tag_subcommand_add_arg_name())
+            .map(|values| values.map(String::from).collect())
+    }
 }
 
 /// Get the tags which should be removed from the commandline


### PR DESCRIPTION
Extract some functionality which was already in `libimagentrytag` and export it in new functions.

Does not change the functionality of anything, but adds more functions to the public interface of the crate.