### PR TITLE
libimagerror: Impl Into<error name> for all <errorkindname>

### DIFF
--- a/libimagerror/src/error_gen.rs
+++ b/libimagerror/src/error_gen.rs
@@ -82,6 +82,14 @@ macro_rules! generate_custom_error_types {
 
         }
 
+        impl Into<$name> for $kindname {
+
+            fn into(self) -> $name {
+                $name::new(self, None)
+            }
+
+        }
+
         impl Display for $name {
 
             fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {

--- a/libimagstore/src/hook/error.rs
+++ b/libimagstore/src/hook/error.rs
@@ -11,14 +11,6 @@ pub trait IntoHookError {
     fn into_hookerror_with_cause(self, cause: Box<Error>) -> HookError;
 }
 
-impl Into<HookError> for HookErrorKind {
-
-    fn into(self) -> HookError {
-        HookError::new(self, None)
-    }
-
-}
-
 impl Into<HookError> for (HookErrorKind, Box<Error>) {
 
     fn into(self) -> HookError {


### PR DESCRIPTION
I totally missed that this is also possible here.