### PR TITLE
Remove unused import

### DIFF
--- a/libimagnotes/src/note.rs
+++ b/libimagnotes/src/note.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::ops::{DerefMut, Deref};
+use std::ops::Deref;
 
 use toml::Value;
 


### PR DESCRIPTION
This is what keeps #209 from building on `rustc 1.10`.