### PR TITLE
Libimagstore/load unload hooks

### DIFF
--- a/imagrc.toml
+++ b/imagrc.toml
@@ -3,6 +3,10 @@
 
 [store]
 
+# Hooks which get executed right before the Store is closed.
+# They get the store path as StoreId passed, so they can alter the complete
+# store, so these hooks should be chosen carefully.
+store-unload-hook-aspects  = [ "debug" ]
 
 pre-create-hook-aspects    = [ "debug" ]
 post-create-hook-aspects   = [ "debug" ]

--- a/libimagstore/src/configuration.rs
+++ b/libimagstore/src/configuration.rs
@@ -117,7 +117,10 @@ pub fn config_is_valid(config: &Option<Value>) -> bool {
     }
 
     match *config {
-        Some(Value::Table(ref t)) => {            has_key_with_string_ary(t, "pre-create-hook-aspects")      &&
+        Some(Value::Table(ref t)) => {
+            has_key_with_string_ary(t, "store-unload-hook-aspects")    &&
+
+            has_key_with_string_ary(t, "pre-create-hook-aspects")      &&
             has_key_with_string_ary(t, "post-create-hook-aspects")     &&
             has_key_with_string_ary(t, "pre-retrieve-hook-aspects")    &&
             has_key_with_string_ary(t, "post-retrieve-hook-aspects")   &&
@@ -141,6 +144,10 @@ pub fn config_is_valid(config: &Option<Value>) -> bool {
             false
         },
     }
+}
+
+pub fn get_store_unload_aspect_names(value: &Option<Value>) -> Vec<String> {
+    get_aspect_names_for_aspect_position("store-unload-hook-aspects", value)
 }
 
 pub fn get_pre_create_aspect_names(value: &Option<Value>) -> Vec<String> {

--- a/libimagstore/src/hook/position.rs
+++ b/libimagstore/src/hook/position.rs
@@ -1,5 +1,7 @@
 #[derive(Debug, Clone)]
 pub enum HookPosition {
+    StoreUnload,
+
     PreCreate,
     PostCreate,
     PreRetrieve,

--- a/libimagstorestdhook/src/debug.rs
+++ b/libimagstorestdhook/src/debug.rs
@@ -43,6 +43,7 @@ impl HookDataAccessorProvider for DebugHook {
         use libimagstore::hook::accessor::HookDataAccessor as HDA;
 
         match self.position {
+            HP::StoreUnload  |
             HP::PreCreate    |
             HP::PreRetrieve  |
             HP::PreDelete    |


### PR DESCRIPTION
Closes #406 


Unfortunately, we cannot have store-load hooks, as the store is the object where the hooks have to be registered. And we cannot register hooks in the store object before the `::new()` call of course, so we have a chicken-egg problem here.

So this PR only implements the `store-unload` hooks.