### PR TITLE
Libimagstore/use error infrastructure

### DIFF
--- a/libimagstore/src/hook/error.rs
+++ b/libimagstore/src/hook/error.rs
@@ -6,16 +6,3 @@ generate_error_types!(HookError, HookErrorKind,
     AccessTypeViolation => "Hook access type violation"
 );
 
-pub trait IntoHookError {
-    fn into_hookerror(self) -> HookError;
-    fn into_hookerror_with_cause(self, cause: Box<Error>) -> HookError;
-}
-
-impl Into<HookError> for (HookErrorKind, Box<Error>) {
-
-    fn into(self) -> HookError {
-        HookError::new(self.0, Some(self.1))
-    }
-
-}
-

--- a/libimagstore/src/hook/error.rs
+++ b/libimagstore/src/hook/error.rs
@@ -1,8 +1,10 @@
-generate_error_imports!();
-use std::convert::Into;
-
-generate_error_types!(HookError, HookErrorKind,
-    HookExecutionError  => "Hook exec error",
-    AccessTypeViolation => "Hook access type violation"
+generate_error_module!(
+    generate_error_types!(HookError, HookErrorKind,
+        HookExecutionError  => "Hook exec error",
+        AccessTypeViolation => "Hook access type violation"
+    );
 );
+
+pub use self::error::HookError;
+pub use self::error::HookErrorKind;
 

--- a/libimagstore/src/lazyfile.rs
+++ b/libimagstore/src/lazyfile.rs
@@ -1,6 +1,6 @@
 use libimagerror::into::IntoError;
 
-use error::{StoreError, StoreErrorKind};
+use error::{StoreError as SE, StoreErrorKind as SEK};
 use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::fs::{File, OpenOptions, create_dir_all};
@@ -33,7 +33,7 @@ impl LazyFile {
     /**
      * Get the mutable file behind a LazyFile object
      */
-    pub fn get_file_mut(&mut self) -> Result<&mut File, StoreError> {
+    pub fn get_file_mut(&mut self) -> Result<&mut File, SE> {
         debug!("Getting lazy file: {:?}", self);
         let file = match *self {
             LazyFile::File(ref mut f) => return {
@@ -41,13 +41,13 @@ impl LazyFile {
                 // access to the file to be in a different context
                 f.seek(SeekFrom::Start(0))
                     .map_err(Box::new)
-                    .map_err(|e| StoreErrorKind::FileNotCreated.into_error_with_cause(e))
+                    .map_err(|e| SEK::FileNotCreated.into_error_with_cause(e))
                     .map(|_| f)
             },
             LazyFile::Absent(ref p) => {
                 try!(open_file(p)
                      .map_err(Box::new)
-                     .map_err(|e| StoreErrorKind::FileNotFound.into_error_with_cause(e))
+                     .map_err(|e| SEK::FileNotFound.into_error_with_cause(e))
                 )
             }
         };
@@ -61,14 +61,14 @@ impl LazyFile {
     /**
      * Create a file out of this LazyFile object
      */
-    pub fn create_file(&mut self) -> Result<&mut File, StoreError> {
+    pub fn create_file(&mut self) -> Result<&mut File, SE> {
         debug!("Creating lazy file: {:?}", self);
         let file = match *self {
             LazyFile::File(ref mut f) => return Ok(f),
             LazyFile::Absent(ref p) => {
                 try!(create_file(p)
                      .map_err(Box::new)
-                     .map_err(|e| StoreErrorKind::FileNotFound.into_error_with_cause(e))
+                     .map_err(|e| SEK::FileNotFound.into_error_with_cause(e))
                 )
             }
         };

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Formatter};
 use std::fmt::Error as FmtError;
 use std::result::Result as RResult;
 
-use error::{StoreError as SE, StoreErrorKind as SEK};
+use error::StoreErrorKind as SEK;
 use store::Result;
 use store::Store;
 
@@ -88,7 +88,7 @@ pub fn build_entry_path(store: &Store, path_elem: &str) -> Result<PathBuf> {
     if path_elem.split('~').last().map_or(false, |v| Version::parse(v).is_err()) {
         debug!("Version cannot be parsed from {:?}", path_elem);
         debug!("Path does not contain version!");
-        return Err(SE::new(SEK::StorePathLacksVersion, None));
+        return Err(SEK::StorePathLacksVersion.into());
     }
     debug!("Version checking succeeded");
 

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Formatter};
 use std::fmt::Error as FmtError;
 use std::result::Result as RResult;
 
-use error::{StoreError, StoreErrorKind};
+use error::{StoreError as SE, StoreErrorKind as SEK};
 use store::Result;
 use store::Store;
 
@@ -88,7 +88,7 @@ pub fn build_entry_path(store: &Store, path_elem: &str) -> Result<PathBuf> {
     if path_elem.split('~').last().map_or(false, |v| Version::parse(v).is_err()) {
         debug!("Version cannot be parsed from {:?}", path_elem);
         debug!("Path does not contain version!");
-        return Err(StoreError::new(StoreErrorKind::StorePathLacksVersion, None));
+        return Err(SE::new(SEK::StorePathLacksVersion, None));
     }
     debug!("Version checking succeeded");
 


### PR DESCRIPTION
Use the `libimagerror` functionality to replace some ugly error handling code.