### PR TITLE
Adds a Makefile for building modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,13 @@
-toml = imag-$@/Cargo.toml
-bin = imag-$@/target/debug/imag-$@
+toml = $@/Cargo.toml
+bin = $@/target/debug/$@
 
 default: all
 
 .PHONY: clean
 
-all: counter link notes store tag view
+all: imag-counter imag-link imag-notes imag-store imag-tag imag-view
 
-counter: prep
-	cargo build --manifest-path $(toml)
-	cp $(bin) out/
-
-link: prep
-	cargo build --manifest-path $(toml)
-	cp $(bin) out/
-
-notes: prep
-	cargo build --manifest-path $(toml)
-	cp $(bin) out/
-
-store: prep
-	cargo build --manifest-path $(toml)
-	cp $(bin) out/
-
-tag: prep
-	cargo build --manifest-path $(toml)
-	cp $(bin) out/
-
-view: prep
+imag-%: prep
 	cargo build --manifest-path $(toml)
 	cp $(bin) out/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+toml = imag-$@/Cargo.toml
+bin = imag-$@/target/debug/imag-$@
+
+default: all
+
+.PHONY: clean
+
+all: counter link notes store tag view
+
+counter: prep
+	cargo build --manifest-path $(toml)
+	cp $(bin) out/
+
+link: prep
+	cargo build --manifest-path $(toml)
+	cp $(bin) out/
+
+notes: prep
+	cargo build --manifest-path $(toml)
+	cp $(bin) out/
+
+store: prep
+	cargo build --manifest-path $(toml)
+	cp $(bin) out/
+
+tag: prep
+	cargo build --manifest-path $(toml)
+	cp $(bin) out/
+
+view: prep
+	cargo build --manifest-path $(toml)
+	cp $(bin) out/
+
+prep:
+	mkdir -p out/
+
+clean:
+	rm -rf out/

--- a/README.md
+++ b/README.md
@@ -89,26 +89,26 @@ provided (as the libraries are work-in-progress).
 
 ### Building
 
-To build a single module:
+One can build all the modules simply by running `make` which defaults to building all the modules
+and placing them in the `out/` directory of the project root.
+
 ```
-$> cd <imag-proj-dir>/imag-<module>
-$> cargo build
+$> make
+  ...
+$> ls out/
+imag-counter  imag-link  imag-notes  imag-store  imag-tag  imag-view
 ```
-It may be tiresome to build all the modules by hand, but one can do something
-like this:
-```
-$> for dir in \
->$(find ./ -maxdepth 1 -path "./imag-*" -name "imag-*" -type d)
->do
->pushd $dir; cargo build; popd
->done
-```
+
+Building all the modules may take some time, so alternatively one can build only a specific module
+by runing `$> make $module` where `$module` is one of  the `imag-$module` names, such as `counter`,
+`link`, etc.
 
 ### Running
 
 To run imag, simply call `./bin/imag`. This script has a function to search for
 modules, which utilizes an environment variable called `IMAG_IS_THE_SHIT`.
 To run imag with all components:
+
 ```
 $> IMAG_IS_THE_SHIT=$(pwd) ./bin/imag
 ```

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ imag-counter  imag-link  imag-notes  imag-store  imag-tag  imag-view
 ```
 
 Building all the modules may take some time, so alternatively one can build only a specific module
-by runing `$> make $module` where `$module` is one of  the `imag-$module` names, such as `counter`,
-`link`, etc.
+by runing `$> make $module` where `$module` is one of  the `imag-*` names, such as `imag-counter`,
+`imag-link`, etc.
 
 ### Running
 


### PR DESCRIPTION
One can now type:

```
$> make
```

Which builds all the modules and places them in a `out/` directory of the project root for easy
finding.

Alternatively one can type:

```
$> make $module
```

Where `$module` is one of the `imag-*` names, such as `counter`, `imag-link`, etc.

To clean up the `out/` directory it's `$> make clean`

-----

The `make clean` could also run `cargo clean` if needbe, but I wasn't sure if that would be desirable or not.