### PR TITLE
Add a set of error kinds to identify the store call the error came from

### DIFF
--- a/libimagstore/src/error.rs
+++ b/libimagstore/src/error.rs
@@ -32,7 +32,17 @@ generate_custom_error_types!(StoreError, StoreErrorKind, CustomErrorData,
     StorePathLacksVersion   => "The supplied store path has no version part",
     GlobError               => "glob() error",
     EncodingError           => "Encoding error",
-    StorePathError          => "Store Path error"
+    StorePathError          => "Store Path error",
+
+    CreateCallError            => "Error when calling create()",
+    RetrieveCallError          => "Error when calling retrieve()",
+    GetCallError               => "Error when calling get()",
+    GetAllVersionsCallError    => "Error when calling get_all_versions()",
+    RetrieveForModuleCallError => "Error when calling retrieve_for_module()",
+    UpdateCallError            => "Error when calling update()",
+    RetrieveCopyCallError      => "Error when calling retrieve_copy()",
+    DeleteCallError            => "Error when calling delete()"
+
 );
 
 generate_custom_error_types!(ParserError, ParserErrorKind, CustomErrorData,


### PR DESCRIPTION
This PR adds some error types which will be used by the Store functions so one can clearly see which store function caused the error.

Basically this adds another level in the error trace, just to be a bit more verbose about the path the error took.