### PR TITLE
Add Developers Certificate of Origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ can review your PR. This means that once _I am_ okay with your patchset, I will
 submit it as PR in the github repository, so more people can review it and CI
 can test it. I might come back to you if something broke in CI or someone has a
 suggestion how to improve your PR.
-I will keep you as author auf the commits.
+I will keep you as author of the commits.
 
 The following sections describe the way how to contribute with github.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,47 @@ from the others by `"/`". See below:
 | test/missing              | Test missing                      | [search][search-test/missing]              |
 | test/new                  | New test                          | [search][search-test/new]                  |
 
+## Developer Certificate of Origin
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
 ## FAQ
 
 _to be written_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ So you want to contribute to imag! Thank you, that's awesome of you!
 If you already have something in mind, go ahead with [the prerequisites
 section](#prerequisites). If you don't know what you could do, start here.
 
+All contribors agree to the
+[developer certificate of origin](#developer-certificate-of-origin)
+by contributing to imag.
+
 ## Finding an issue
 
 Finding an issue is simple: We have

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,27 @@ All contribors agree to the
 [developer certificate of origin](#developer-certificate-of-origin)
 by contributing to imag.
 
+## Without Github
+
+If you do not want to use github for your contribution, this is completely okay
+with us. Feel free to contact [me](https://github.com/matthiasbeyer) via mail,
+feel also free to submit patches via mail (use `git format-patch` and
+`git send-email`, always add a cover letter to describe your submission).
+
+Also ensure that each commit has
+[a "Signed-off-by: " line](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for).
+By adding that line, you agree to our
+[developer certificate of origin](#developer-certificate-of-origin).
+
+We do not have a mailinglist, so we do not have a process where all contributors
+can review your PR. This means that once _I am_ okay with your patchset, I will
+submit it as PR in the github repository, so more people can review it and CI
+can test it. I might come back to you if something broke in CI or someone has a
+suggestion how to improve your PR.
+I will keep you as author auf the commits.
+
+The following sections describe the way how to contribute with github.
+
 ## Finding an issue
 
 Finding an issue is simple: We have


### PR DESCRIPTION
I'm not sure here: We do not have a license-header in the files itself, but a license file which lives in the repository.

We might have to fix this.

@neithernut , @TheNeikos and maybe @llogiq ... what do you think on the subject of having a license statement in all files - is it necessary?