### PR TITLE
Libimagstore/storify

### DIFF
--- a/libimagstore/src/error.rs
+++ b/libimagstore/src/error.rs
@@ -34,6 +34,7 @@ generate_custom_error_types!(StoreError, StoreErrorKind, CustomErrorData,
     EncodingError           => "Encoding error",
     StorePathError          => "Store Path error",
     EntryRenameError        => "Entry rename error",
+    StoreIdHandlingError    => "StoreId handling error",
 
     CreateCallError            => "Error when calling create()",
     RetrieveCallError          => "Error when calling retrieve()",

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -344,13 +344,10 @@ impl Store {
             se
         });
 
-        id.unstorified(self)
-            .and_then(|id| {
-                let mut fle = FileLockEntry::new(self, Entry::new(id));
-                self.execute_hooks_for_mut_file(self.post_create_aspects.clone(), &mut fle)
-                    .map_err_into(SEK::PostHookExecuteError)
-                    .map(|_| fle)
-            })
+        let mut fle = FileLockEntry::new(self, Entry::new(id));
+        self.execute_hooks_for_mut_file(self.post_create_aspects.clone(), &mut fle)
+            .map_err_into(SEK::PostHookExecuteError)
+            .map(|_| fle)
             .map_err_into(SEK::CreateCallError)
     }
 

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -344,10 +344,13 @@ impl Store {
             se
         });
 
-        let mut fle = FileLockEntry::new(self, Entry::new(id));
-        self.execute_hooks_for_mut_file(self.post_create_aspects.clone(), &mut fle)
-            .map_err_into(SEK::PostHookExecuteError)
-            .map(|_| fle)
+        id.unstorified(self)
+            .and_then(|id| {
+                let mut fle = FileLockEntry::new(self, Entry::new(id));
+                self.execute_hooks_for_mut_file(self.post_create_aspects.clone(), &mut fle)
+                    .map_err_into(SEK::PostHookExecuteError)
+                    .map(|_| fle)
+            })
             .map_err_into(SEK::CreateCallError)
     }
 

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -9,6 +9,7 @@ use std::fmt::Error as FmtError;
 use std::result::Result as RResult;
 
 use error::StoreErrorKind as SEK;
+use error::MapErrInto;
 use store::Result;
 use store::Store;
 
@@ -24,6 +25,13 @@ impl StoreId {
         new_id.push(self);
         debug!("Created: '{:?}'", new_id);
         StoreId::from(new_id)
+    }
+
+    pub fn unstorified(self, store: &Store) -> Result<StoreId> {
+        self.strip_prefix(store.path())
+            .map(PathBuf::from)
+            .map(StoreId::from)
+            .map_err_into(SEK::StoreIdHandlingError)
     }
 
 }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -19,11 +19,16 @@ pub struct StoreId(PathBuf);
 impl StoreId {
 
     pub fn storified(self, store: &Store) -> StoreId {
-        debug!("Create new store id out of: {:?} and {:?}", store.path(), self);
-        let mut new_id = store.path().clone();
-        new_id.push(self);
-        debug!("Created: '{:?}'", new_id);
-        StoreId::from(new_id)
+        if self.starts_with(store.path()) {
+            debug!("Not storifying {:?}, because it is already.", self);
+            self
+        } else {
+            debug!("Create new store id out of: {:?} and {:?}", store.path(), self);
+            let mut new_id = store.path().clone();
+            new_id.push(self);
+            debug!("Created: '{:?}'", new_id);
+            StoreId::from(new_id)
+        }
     }
 
 }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -9,7 +9,6 @@ use std::fmt::Error as FmtError;
 use std::result::Result as RResult;
 
 use error::StoreErrorKind as SEK;
-use error::MapErrInto;
 use store::Result;
 use store::Store;
 
@@ -25,13 +24,6 @@ impl StoreId {
         new_id.push(self);
         debug!("Created: '{:?}'", new_id);
         StoreId::from(new_id)
-    }
-
-    pub fn unstorified(self, store: &Store) -> Result<StoreId> {
-        self.strip_prefix(store.path())
-            .map(PathBuf::from)
-            .map(StoreId::from)
-            .map_err_into(SEK::StoreIdHandlingError)
     }
 
 }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -16,6 +16,18 @@ use store::Store;
 #[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub struct StoreId(PathBuf);
 
+impl StoreId {
+
+    pub fn storified(self, store: &Store) -> StoreId {
+        debug!("Create new store id out of: {:?} and {:?}", store.path(), self);
+        let mut new_id = store.path().clone();
+        new_id.push(self);
+        debug!("Created: '{:?}'", new_id);
+        StoreId::from(new_id)
+    }
+
+}
+
 impl Into<PathBuf> for StoreId {
 
     fn into(self) -> PathBuf {


### PR DESCRIPTION
This is a PR where I try to introduce a concept to differentiate between internal and external store ids.

Internal store ids should contain the full path to an entry inside the store. They should be absolute to the filesystem root.

External store ids should be absolute to the store root they live in.

This makes things rather complicated, actually, as the internal setup of the store makes differentiation rather complicated.