### PR TITLE
libimagentrylist: Make CoreLister generic

### DIFF
--- a/imag-diary/src/list.rs
+++ b/imag-diary/src/list.rs
@@ -7,6 +7,7 @@ use libimagdiary::error::DiaryErrorKind as DEK;
 use libimagentrylist::listers::core::CoreLister;
 use libimagentrylist::lister::Lister;
 use libimagrt::runtime::Runtime;
+use libimagstore::store::Entry;
 use libimagstore::storeid::StoreId;
 use libimagerror::trace::trace_error;
 
@@ -41,7 +42,7 @@ pub fn list(rt: &Runtime) {
 
             let base = rt.store().path();
 
-            CoreLister::new(&move |e| location_to_listing_string(e.get_location(), base))
+            CoreLister::new(&move |e: &Entry| location_to_listing_string(e.get_location(), base))
                 .list(es) // TODO: Do not ignore non-ok()s
                 .map_err(|e| DE::new(DEK::IOError, Some(Box::new(e))))
         })

--- a/libimagentrylist/src/listers/core.rs
+++ b/libimagentrylist/src/listers/core.rs
@@ -7,21 +7,21 @@ use result::Result;
 use libimagstore::store::FileLockEntry;
 use libimagstore::store::Entry;
 
-pub struct CoreLister<'a> {
-    lister: &'a Fn(&Entry) -> String,
+pub struct CoreLister<T: Fn(&Entry) -> String> {
+    lister: Box<T>,
 }
 
-impl<'a> CoreLister<'a> {
+impl<T: Fn(&Entry) -> String> CoreLister<T> {
 
-    pub fn new(lister: &'a Fn(&Entry) -> String) -> CoreLister<'a> {
+    pub fn new(lister: T) -> CoreLister<T> {
         CoreLister {
-            lister: lister,
+            lister: Box::new(lister),
         }
     }
 
 }
 
-impl<'a> Lister for CoreLister<'a> {
+impl<T: Fn(&Entry) -> String> Lister for CoreLister<T> {
 
     fn list<'b, I: Iterator<Item = FileLockEntry<'b>>>(&self, entries: I) -> Result<()> {
         use error::ListError as LE;


### PR DESCRIPTION
Make CoreLister generic, so we can pass functions _and_ closures into it.