### PR TITLE
Fix Display impl for StoreId by using lossy string rep if PathBuf::to…

### DIFF
--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -46,7 +46,7 @@ impl Display for StoreId {
     fn fmt(&self, fmt: &mut Formatter) -> RResult<(), FmtError> {
         match self.0.to_str() {
             Some(s) => write!(fmt, "{}", s),
-            None    => write!(fmt, "<non-UTF8-StoreId>"), // TODO: Sure here?
+            None    => write!(fmt, "{}", self.0.to_string_lossy()),
         }
     }
 


### PR DESCRIPTION
…_str() fails

As discussed in https://github.com/matthiasbeyer/imag/pull/487#discussion_r69544153