### PR TITLE
libimagstore/internal storeid type

### DIFF
--- a/libimagstore/src/entrystoreid.rs
+++ b/libimagstore/src/entrystoreid.rs
@@ -27,6 +27,14 @@ impl Into<StoreId> for EntryStoreId {
 
 }
 
+impl Deref for EntryStoreId {
+    type Target = StoreId;
+
+    fn deref(&self) -> &StoreId {
+        &self.0
+    }
+}
+
 impl IntoStoreId for EntryStoreId {
 
     fn into_storeid(self) -> StoreId {

--- a/libimagstore/src/entrystoreid.rs
+++ b/libimagstore/src/entrystoreid.rs
@@ -1,5 +1,5 @@
 use std::fmt::Error as FmtError;
-use std::fmt::{Display, Debug, Formatter};
+use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::result::Result as RResult;
 
@@ -13,7 +13,7 @@ pub struct EntryStoreId(StoreId);
 
 impl EntryStoreId {
 
-    fn new(store: &Store, si: StoreId) -> Result<EntryStoreId> {
+    pub fn new(store: &Store, si: StoreId) -> Result<EntryStoreId> {
         si.unstorified(store).map(|si| EntryStoreId(si))
     }
 

--- a/libimagstore/src/entrystoreid.rs
+++ b/libimagstore/src/entrystoreid.rs
@@ -2,6 +2,7 @@ use std::fmt::Error as FmtError;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::result::Result as RResult;
+use std::ops::Deref;
 
 use store::Result;
 use store::Store;

--- a/libimagstore/src/entrystoreid.rs
+++ b/libimagstore/src/entrystoreid.rs
@@ -9,7 +9,7 @@ use store::Store;
 use storeid::IntoStoreId;
 use storeid::StoreId;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub struct EntryStoreId(StoreId);
 
 impl EntryStoreId {

--- a/libimagstore/src/entrystoreid.rs
+++ b/libimagstore/src/entrystoreid.rs
@@ -60,3 +60,17 @@ impl Display for EntryStoreId {
 
 }
 
+pub trait IntoEntryStoreId {
+
+    fn into_entry_store_id(self, &Store) -> Result<EntryStoreId>;
+
+}
+
+impl<I: IntoStoreId> IntoEntryStoreId for I {
+
+    fn into_entry_store_id(self, store: &Store) -> Result<EntryStoreId> {
+        EntryStoreId::new(store, self.into_storeid())
+    }
+
+}
+

--- a/libimagstore/src/entrystoreid.rs
+++ b/libimagstore/src/entrystoreid.rs
@@ -1,0 +1,53 @@
+use std::fmt::Error as FmtError;
+use std::fmt::{Display, Debug, Formatter};
+use std::path::PathBuf;
+use std::result::Result as RResult;
+
+use store::Result;
+use store::Store;
+use storeid::IntoStoreId;
+use storeid::StoreId;
+
+#[derive(Debug, Clone)]
+pub struct EntryStoreId(StoreId);
+
+impl EntryStoreId {
+
+    fn new(store: &Store, si: StoreId) -> Result<EntryStoreId> {
+        si.unstorified(store).map(|si| EntryStoreId(si))
+    }
+
+}
+
+impl Into<StoreId> for EntryStoreId {
+
+    fn into(self) -> StoreId {
+        self.0
+    }
+
+}
+
+impl IntoStoreId for EntryStoreId {
+
+    fn into_storeid(self) -> StoreId {
+        self.into()
+    }
+
+}
+
+impl From<PathBuf> for EntryStoreId {
+
+    fn from(pb: PathBuf) -> EntryStoreId {
+        EntryStoreId(StoreId::from(pb))
+    }
+
+}
+
+impl Display for EntryStoreId {
+
+    fn fmt(&self, fmt: &mut Formatter) -> RResult<(), FmtError> {
+        write!(fmt, "{}", self.0)
+    }
+
+}
+

--- a/libimagstore/src/lib.rs
+++ b/libimagstore/src/lib.rs
@@ -33,4 +33,5 @@ pub mod hook;
 pub mod store;
 mod configuration;
 mod lazyfile;
+mod entrystoreid;
 

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1337,37 +1337,6 @@ impl Entry {
         Self::from_str(loc, &text[..])
     }
 
-    pub fn from_str<S: IntoStoreId>(loc: S, s: &str) -> Result<Entry> {
-        debug!("Building entry from string");
-        lazy_static! {
-            static ref RE: Regex = Regex::new(r"(?smx)
-                ^---$
-                (?P<header>.*) # Header
-                ^---$\n
-                (?P<content>.*) # Content
-            ").unwrap();
-        }
-
-        let matches = match RE.captures(s) {
-            None    => return Err(SE::new(SEK::MalformedEntry, None)),
-            Some(s) => s,
-        };
-
-        let header = match matches.name("header") {
-            None    => return Err(SE::new(SEK::MalformedEntry, None)),
-            Some(s) => s
-        };
-
-        let content = matches.name("content").unwrap_or("");
-
-        debug!("Header and content found. Yay! Building Entry object now");
-        Ok(Entry {
-            location: loc.into_storeid(),
-            header: try!(EntryHeader::parse(header)),
-            content: content.into(),
-        })
-    }
-
     pub fn to_str(&self) -> String {
         format!("---{header}---\n{content}",
                 header  = ::toml::encode_str(&self.header.header),
@@ -1588,29 +1557,6 @@ mod test {
 version = \"0.0.3\"
 ---
 Hai";
-
-    #[test]
-    fn test_entry_from_str() {
-        use super::Entry;
-        use std::path::PathBuf;
-        println!("{}", TEST_ENTRY);
-        let entry = Entry::from_str(PathBuf::from("/test/foo~1.3"),
-                                    TEST_ENTRY).unwrap();
-
-        assert_eq!(entry.content, "Hai");
-    }
-
-    #[test]
-    fn test_entry_to_str() {
-        use super::Entry;
-        use std::path::PathBuf;
-        println!("{}", TEST_ENTRY);
-        let entry = Entry::from_str(PathBuf::from("/test/foo~1.3"),
-                                    TEST_ENTRY).unwrap();
-        let string = entry.to_str();
-
-        assert_eq!(TEST_ENTRY, string);
-    }
 
     #[test]
     fn test_walk_header_simple() {

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -9,6 +9,7 @@ use std::fmt::Error as FmtError;
 use std::result::Result as RResult;
 
 use error::StoreErrorKind as SEK;
+use error::MapErrInto;
 use store::Result;
 use store::Store;
 
@@ -29,6 +30,13 @@ impl StoreId {
             debug!("Created: '{:?}'", new_id);
             StoreId::from(new_id)
         }
+    }
+
+    pub fn unstorified(self, store: &Store) -> Result<StoreId> {
+        self.strip_prefix(store.path())
+            .map(PathBuf::from)
+            .map(StoreId::from)
+            .map_err_into(SEK::StoreIdHandlingError)
     }
 
 }


### PR DESCRIPTION
@TheNeikos please look at this.

I'm trying to solve this huge source of bugs right now... but I still think it is a bit ugly how I solve it.

Maybe we should rework the _whole_ codebase (I mean with ignoring backwards compatibility) to fix this issue.

This is another approach to make the internal use of store ids absolute _to the store root_ rather than to the filesystem root.

I'm not sure I did it right and I guess there are still flaws. For instance, we might preserve the actual `StoreId` instance when creating a `EntryStoreId` instance from it and offer the possibility to fully restore it in `Into<Storeid>`.