### PR TITLE
Add a `fold_ok` utility.

### DIFF
--- a/libimagentrylist/Cargo.toml
+++ b/libimagentrylist/Cargo.toml
@@ -14,3 +14,6 @@ path = "../libimagstore"
 [dependencies.libimagerror]
 path = "../libimagerror"
 
+[dependencies.libimagutil]
+path = "../libimagutil"
+

--- a/libimagentrylist/src/lib.rs
+++ b/libimagentrylist/src/lib.rs
@@ -19,6 +19,7 @@ extern crate clap;
 extern crate toml;
 
 extern crate libimagstore;
+extern crate libimagutil;
 #[macro_use] extern crate libimagerror;
 
 pub mod cli;

--- a/libimagentrylist/src/listers/line.rs
+++ b/libimagentrylist/src/listers/line.rs
@@ -5,6 +5,7 @@ use lister::Lister;
 use result::Result;
 
 use libimagstore::store::FileLockEntry;
+use libimagutil::iter::fold_ok;
 
 pub struct LineLister<'a> {
     unknown_output: &'a str,
@@ -26,13 +27,10 @@ impl<'a> Lister for LineLister<'a> {
         use error::ListError as LE;
         use error::ListErrorKind as LEK;
 
-        entries.fold(Ok(()), |accu, entry| {
-            accu.and_then(|_| {
-                    write!(stdout(), "{:?}\n",
-                            entry.get_location().to_str().unwrap_or(self.unknown_output))
-                        .map_err(|e| LE::new(LEK::FormatError, Some(Box::new(e))))
-                })
-            })
+        fold_ok(entries, |entry| {
+            write!(stdout(), "{:?}\n", entry.get_location().to_str().unwrap_or(self.unknown_output))
+                .map_err(|e| LE::new(LEK::FormatError, Some(Box::new(e))))
+        })
     }
 
 }

--- a/libimagentrylist/src/listers/line.rs
+++ b/libimagentrylist/src/listers/line.rs
@@ -5,7 +5,7 @@ use lister::Lister;
 use result::Result;
 
 use libimagstore::store::FileLockEntry;
-use libimagutil::iter::fold_ok;
+use libimagutil::iter::FoldResult;
 
 pub struct LineLister<'a> {
     unknown_output: &'a str,
@@ -27,7 +27,7 @@ impl<'a> Lister for LineLister<'a> {
         use error::ListError as LE;
         use error::ListErrorKind as LEK;
 
-        fold_ok(entries, |entry| {
+        entries.fold_defresult(|entry| {
             write!(stdout(), "{:?}\n", entry.get_location().to_str().unwrap_or(self.unknown_output))
                 .map_err(|e| LE::new(LEK::FormatError, Some(Box::new(e))))
         })

--- a/libimagentrylist/src/listers/path.rs
+++ b/libimagentrylist/src/listers/path.rs
@@ -5,6 +5,7 @@ use lister::Lister;
 use result::Result;
 
 use libimagstore::store::FileLockEntry;
+use libimagutil::iter::fold_ok;
 
 pub struct PathLister {
     absolute: bool,
@@ -26,8 +27,8 @@ impl Lister for PathLister {
         use error::ListError as LE;
         use error::ListErrorKind as LEK;
 
-        entries.fold(Ok(()), |accu, entry| {
-            accu.and_then(|_| Ok(entry.get_location().clone()))
+        fold_ok(entries, |entry| {
+            Ok(entry.get_location().clone())
                 .and_then(|pb| {
                     if self.absolute {
                         pb.canonicalize().map_err(|e| LE::new(LEK::FormatError, Some(Box::new(e))))

--- a/libimagentrylist/src/listers/path.rs
+++ b/libimagentrylist/src/listers/path.rs
@@ -5,7 +5,7 @@ use lister::Lister;
 use result::Result;
 
 use libimagstore::store::FileLockEntry;
-use libimagutil::iter::fold_ok;
+use libimagutil::iter::FoldResult;
 
 pub struct PathLister {
     absolute: bool,
@@ -27,7 +27,7 @@ impl Lister for PathLister {
         use error::ListError as LE;
         use error::ListErrorKind as LEK;
 
-        fold_ok(entries, |entry| {
+        entries.fold_defresult(|entry| {
             Ok(entry.get_location().clone())
                 .and_then(|pb| {
                     if self.absolute {

--- a/libimagstore/src/hook/aspect.rs
+++ b/libimagstore/src/hook/aspect.rs
@@ -1,5 +1,5 @@
 use libimagerror::trace::trace_error;
-use libimagutil::iter::fold_ok;
+use libimagutil::iter::FoldResult;
 
 use store::FileLockEntry;
 use storeid::StoreId;
@@ -46,7 +46,7 @@ impl StoreIdAccessor for Aspect {
             return Err(HE::new(HEK::AccessTypeViolation, None));
         }
 
-        fold_ok(accessors.iter(), |accessor| {
+        accessors.iter().fold_defresult(|accessor| {
             let res = match accessor {
                 &HDA::StoreIdAccess(accessor) => accessor.access(id),
                 _ => unreachable!(),
@@ -88,7 +88,7 @@ impl MutableHookDataAccessor for Aspect {
         // More sophisticated version would check whether there are _chunks_ of
         // NonMutableAccess accessors and execute these chunks in parallel. We do not have
         // performance concerns yet, so this is okay.
-        fold_ok(accessors.iter(), |accessor| {
+        accessors.iter().fold_defresult(|accessor| {
             let res = match accessor {
                 &HDA::MutableAccess(ref accessor)    => accessor.access_mut(fle),
                 &HDA::NonMutableAccess(ref accessor) => accessor.access(fle),
@@ -118,7 +118,7 @@ impl NonMutableHookDataAccessor for Aspect {
             return Err(HE::new(HEK::AccessTypeViolation, None));
         }
 
-        fold_ok(accessors.iter(), |accessor| {
+        accessors.iter().fold_defresult(|accessor| {
             let res = match accessor {
                 &HDA::NonMutableAccess(accessor) => accessor.access(fle),
                 _ => unreachable!(),

--- a/libimagstore/src/hook/aspect.rs
+++ b/libimagstore/src/hook/aspect.rs
@@ -1,4 +1,5 @@
 use libimagerror::trace::trace_error;
+use libimagutil::iter::fold_ok;
 
 use store::FileLockEntry;
 use storeid::StoreId;
@@ -45,29 +46,25 @@ impl StoreIdAccessor for Aspect {
             return Err(HE::new(HEK::AccessTypeViolation, None));
         }
 
-        accessors
-            .iter()
-            .fold(Ok(()), |acc, accessor| {
-                acc.and_then(|_| {
-                    let res = match accessor {
-                        &HDA::StoreIdAccess(accessor) => accessor.access(id),
-                        _ => unreachable!(),
-                    };
+        fold_ok(accessors.iter(), |accessor| {
+            let res = match accessor {
+                &HDA::StoreIdAccess(accessor) => accessor.access(id),
+                _ => unreachable!(),
+            };
 
-                    match res {
-                        Ok(res) => Ok(res),
-                        Err(e) => {
-                            if !e.is_aborting() {
-                                trace_error(&e);
-                                // ignore error if it is not aborting, as we printed it already
-                                Ok(())
-                            } else {
-                                Err(e)
-                            }
-                        }
+            match res {
+                Ok(res) => Ok(res),
+                Err(e) => {
+                    if !e.is_aborting() {
+                        trace_error(&e);
+                        // ignore error if it is not aborting, as we printed it already
+                        Ok(())
+                    } else {
+                        Err(e)
                     }
-                })
-            })
+                }
+            }
+        })
     }
 }
 
@@ -91,27 +88,25 @@ impl MutableHookDataAccessor for Aspect {
         // More sophisticated version would check whether there are _chunks_ of
         // NonMutableAccess accessors and execute these chunks in parallel. We do not have
         // performance concerns yet, so this is okay.
-        accessors.iter().fold(Ok(()), |acc, accessor| {
-            acc.and_then(|_| {
-                let res = match accessor {
-                    &HDA::MutableAccess(ref accessor)    => accessor.access_mut(fle),
-                    &HDA::NonMutableAccess(ref accessor) => accessor.access(fle),
-                    _ => unreachable!(),
-                };
+        fold_ok(accessors.iter(), |accessor| {
+            let res = match accessor {
+                &HDA::MutableAccess(ref accessor)    => accessor.access_mut(fle),
+                &HDA::NonMutableAccess(ref accessor) => accessor.access(fle),
+                _ => unreachable!(),
+            };
 
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => {
-                        if !e.is_aborting() {
-                            trace_error(&e);
-                            // ignore error if it is not aborting, as we printed it already
-                            Ok(())
-                        } else {
-                            Err(e)
-                        }
+            match res {
+                Ok(res) => Ok(res),
+                Err(e) => {
+                    if !e.is_aborting() {
+                        trace_error(&e);
+                        // ignore error if it is not aborting, as we printed it already
+                        Ok(())
+                    } else {
+                        Err(e)
                     }
                 }
-            })
+            }
         })
     }
 }
@@ -123,29 +118,25 @@ impl NonMutableHookDataAccessor for Aspect {
             return Err(HE::new(HEK::AccessTypeViolation, None));
         }
 
-        accessors
-            .iter()
-            .fold(Ok(()), |acc, accessor| {
-                acc.and_then(|_| {
-                    let res = match accessor {
-                        &HDA::NonMutableAccess(accessor) => accessor.access(fle),
-                        _ => unreachable!(),
-                    };
+        fold_ok(accessors.iter(), |accessor| {
+            let res = match accessor {
+                &HDA::NonMutableAccess(accessor) => accessor.access(fle),
+                _ => unreachable!(),
+            };
 
-                    match res {
-                        Ok(res) => Ok(res),
-                        Err(e) => {
-                            if !e.is_aborting() {
-                                trace_error(&e);
-                                // ignore error if it is not aborting, as we printed it already
-                                Ok(())
-                            } else {
-                                Err(e)
-                            }
-                        }
+            match res {
+                Ok(res) => Ok(res),
+                Err(e) => {
+                    if !e.is_aborting() {
+                        trace_error(&e);
+                        // ignore error if it is not aborting, as we printed it already
+                        Ok(())
+                    } else {
+                        Err(e)
                     }
-                })
-            })
+                }
+            }
+        })
     }
 }
 

--- a/libimagutil/src/iter.rs
+++ b/libimagutil/src/iter.rs
@@ -1,8 +1,30 @@
-/// Processes `iter` returning the last successful result or the first error.
-pub fn fold_ok<X, I, R, E, F>(iter: I, mut func: F) -> Result<R, E>
-    where I: Iterator<Item = X>,
-          R: Default,
-          F: FnMut(X) -> Result<R, E>
-{
-    iter.fold(Ok(R::default()), |acc, item| acc.and_then(|_| func(item)))
+/// Folds its contents to a result.
+pub trait FoldResult: Sized {
+    type Item;
+
+    /// Processes all contained items returning the last successful result or the first error.
+    /// If there are no items, returns `Ok(R::default())`.
+    fn fold_defresult<R, E, F>(self, func: F) -> Result<R, E>
+        where R: Default,
+              F: FnMut(Self::Item)
+        -> Result<R, E>
+    {
+        self.fold_result(R::default(), func)
+    }
+
+    /// Processes all contained items returning the last successful result or the first error.
+    /// If there are no items, returns `Ok(default)`.
+    fn fold_result<R, E, F>(self, default: R, mut func: F) -> Result<R, E>
+        where F: FnMut(Self::Item) -> Result<R, E>;
 }
+
+impl<X, I: Iterator<Item = X>> FoldResult for I {
+    type Item = X;
+
+    fn fold_result<R, E, F>(self, default: R, mut func: F) -> Result<R, E>
+        where F: FnMut(Self::Item) -> Result<R, E>
+    {
+        self.fold(Ok(default), |acc, item| acc.and_then(|_| func(item)))
+    }
+}
+

--- a/libimagutil/src/iter.rs
+++ b/libimagutil/src/iter.rs
@@ -1,0 +1,8 @@
+/// Processes `iter` returning the last successful result or the first error.
+pub fn fold_ok<X, I, R, E, F>(iter: I, mut func: F) -> Result<R, E>
+    where I: Iterator<Item = X>,
+          R: Default,
+          F: FnMut(X) -> Result<R, E>
+{
+    iter.fold(Ok(R::default()), |acc, item| acc.and_then(|_| func(item)))
+}

--- a/libimagutil/src/lib.rs
+++ b/libimagutil/src/lib.rs
@@ -18,5 +18,6 @@
 extern crate regex;
 
 pub mod ismatch;
+pub mod iter;
 pub mod key_value_split;
 pub mod variants;


### PR DESCRIPTION
Add a utility that folds an iterator into a result and uses it to reduce
boilerplate in the codebase.