### PR TITLE
Temporary fix: Check whether an StoreId is an external link by str::c…

### DIFF
--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -97,7 +97,7 @@ pub trait ExternalLinker : InternalLinker {
 /// Check whether the StoreId starts with `/link/external/`
 pub fn is_external_link_storeid(id: &StoreId) -> bool {
     debug!("Checking whether this is a /link/external/*: '{:?}'", id);
-    id.to_str().map(|s| s.contains("/link/external/")).unwrap_or(false)
+    id.parent().map(|par| par.ends_with("/link/external")).unwrap_or(false)
 }
 
 fn get_external_link_from_file(entry: &FileLockEntry) -> Result<Url> {

--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -97,7 +97,7 @@ pub trait ExternalLinker : InternalLinker {
 /// Check whether the StoreId starts with `/link/external/`
 pub fn is_external_link_storeid(id: &StoreId) -> bool {
     debug!("Checking whether this is a /link/external/*: '{:?}'", id);
-    id.starts_with("/link/external/")
+    id.to_str().map(|s| s.contains("/link/external/")).unwrap_or(false)
 }
 
 fn get_external_link_from_file(entry: &FileLockEntry) -> Result<Url> {


### PR DESCRIPTION
…ontains()

This is a temporary fix as long as we do not have a clear model how we
handle internal/external StoreId types.

@TheNeikos, @neithernut here we can see what the problems are if we do not have a clear invariant for this type. :cry: 