### PR TITLE
Add utility for calling trace_error() and exit()

### DIFF
--- a/imag-bookmark/src/main.rs
+++ b/imag-bookmark/src/main.rs
@@ -17,7 +17,7 @@ use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
 use libimagbookmark::collection::BookmarkCollection;
 use libimagbookmark::link::Link as BookmarkLink;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 
 mod ui;
 
@@ -96,10 +96,7 @@ fn list(rt: &Runtime) {
                     };
                     debug!("... ready with listing");
                 },
-                Err(e) => {
-                    trace_error(&e);
-                    exit(1);
-                },
+                Err(e) => trace_error_exit(&e, 1),
             }
         });
     info!("Ready");

--- a/imag-counter/src/create.rs
+++ b/imag-counter/src/create.rs
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-use std::process::exit;
 
 use libimagrt::runtime::Runtime;
 use libimagerror::trace::trace_error_exit;

--- a/imag-counter/src/create.rs
+++ b/imag-counter/src/create.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::process::exit;
 
 use libimagrt::runtime::Runtime;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::trace_error_exit;
 use libimagcounter::counter::Counter;
 
 pub fn create(rt: &Runtime) {
@@ -20,8 +20,7 @@ pub fn create(rt: &Runtime) {
             match Counter::new(rt.store(), String::from(name), init) {
                 Err(e) => {
                     warn!("Could not create Counter '{}' with initial value '{}'", name, init);
-                    trace_error(&e);
-                    exit(1);
+                    trace_error_exit(&e, 1);
                 },
                 Ok(_) => info!("Created Counter '{}' with initial value '{}'", name, init),
             }

--- a/imag-counter/src/delete.rs
+++ b/imag-counter/src/delete.rs
@@ -1,5 +1,3 @@
-use std::process::exit;
-
 use libimagrt::runtime::Runtime;
 use libimagerror::trace::trace_error_exit;
 use libimagcounter::counter::Counter;

--- a/imag-counter/src/delete.rs
+++ b/imag-counter/src/delete.rs
@@ -1,7 +1,7 @@
 use std::process::exit;
 
 use libimagrt::runtime::Runtime;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::trace_error_exit;
 use libimagcounter::counter::Counter;
 
 pub fn delete(rt: &Runtime) {
@@ -13,8 +13,7 @@ pub fn delete(rt: &Runtime) {
             let name = String::from(scmd.value_of("name").unwrap()); // safe because clap enforces
 
             if let Err(e) = Counter::delete(name, rt.store()) {
-                trace_error(&e);
-                exit(1);
+                trace_error_exit(&e, 1);
             }
 
             info!("Ok");

--- a/imag-counter/src/interactive.rs
+++ b/imag-counter/src/interactive.rs
@@ -10,7 +10,7 @@ use libimagcounter::counter::Counter;
 use libimagcounter::error::CounterError;
 use libimagrt::runtime::Runtime;
 use libimagutil::key_value_split::IntoKeyValue;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 
 type Result<T> = RResult<T, CounterError>;
 
@@ -47,8 +47,7 @@ pub fn interactive(rt: &Runtime) {
 
         let mut input = String::new();
         if let Err(e) = stdin().read_line(&mut input) {
-            trace_error(&e);
-            exit(1);
+            trace_error_exit(&e, 1);
         }
 
         let cont = if !input.is_empty() {

--- a/imag-counter/src/main.rs
+++ b/imag-counter/src/main.rs
@@ -27,7 +27,7 @@ use std::str::FromStr;
 
 use libimagrt::setup::generate_runtime_setup;
 use libimagcounter::counter::Counter;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 use libimagutil::key_value_split::IntoKeyValue;
 
 mod create;
@@ -75,7 +75,7 @@ fn main() {
                         Counter::load(String::from(name), rt.store())
                             .map(|mut counter| {
                                 match counter.inc() {
-                                    Err(e) => { trace_error(&e); exit(1); },
+                                    Err(e) => trace_error_exit(&e, 1),
                                     Ok(_) => info!("Ok"),
                                 }
                             })
@@ -84,7 +84,7 @@ fn main() {
                         Counter::load(String::from(name), rt.store())
                             .map(|mut counter| {
                                 match counter.dec() {
-                                    Err(e) => { trace_error(&e); exit(1); },
+                                    Err(e) => trace_error_exit(&e, 1),
                                     Ok(_) => info!("Ok"),
                                 }
                             })
@@ -93,7 +93,7 @@ fn main() {
                         Counter::load(String::from(name), rt.store())
                             .map(|mut counter| {
                                 match counter.reset() {
-                                    Err(e) => { trace_error(&e); exit(1); },
+                                    Err(e) => trace_error_exit(&e, 1),
                                     Ok(_) => info!("Ok"),
                                 }
                             })
@@ -114,7 +114,7 @@ fn main() {
                         Counter::load(String::from(key), rt.store())
                             .map(|mut counter| {
                                 match counter.set(value) {
-                                    Err(e) => { trace_error(&e); exit(1); },
+                                    Err(e) => trace_error_exit(&e, 1),
                                     Ok(_) => info!("Ok"),
                                 }
                             })

--- a/imag-diary/src/delete.rs
+++ b/imag-diary/src/delete.rs
@@ -4,7 +4,7 @@ use chrono::naive::datetime::NaiveDateTime;
 use libimagdiary::diary::Diary;
 use libimagdiary::diaryid::DiaryId;
 use libimagrt::runtime::Runtime;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::trace_error_exit;
 use libimagtimeui::datetime::DateTime;
 use libimagtimeui::parse::Parse;
 
@@ -40,10 +40,7 @@ pub fn delete(rt: &Runtime) {
     let to_del = match to_del {
         Some(Ok(e)) => e,
 
-        Some(Err(e)) => {
-            trace_error(&e);
-            exit(1);
-        },
+        Some(Err(e)) => trace_error_exit(&e, 1),
         None => {
             warn!("No entry");
             exit(1);
@@ -57,10 +54,7 @@ pub fn delete(rt: &Runtime) {
 
     match diary.delete_entry(to_del) {
         Ok(_) => info!("Ok"),
-        Err(e) => {
-            trace_error(&e);
-            exit(1);
-        },
+        Err(e) => trace_error_exit(&e, 1),
     }
 }
 

--- a/imag-diary/src/view.rs
+++ b/imag-diary/src/view.rs
@@ -28,9 +28,7 @@ pub fn view(rt: &Runtime) {
                 println!("\n---\n");
             }
         },
-        Err(e) => {
-            trace_error(&e);
-        },
+        Err(e) => trace_error(&e),
     }
 }
 

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -34,7 +34,7 @@ use libimagstore::error::StoreError;
 use libimagstore::store::Entry;
 use libimagstore::store::FileLockEntry;
 use libimagstore::store::Store;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 use libimagentrylink::external::ExternalLinker;
 use clap::ArgMatches;
 use url::Url;
@@ -117,8 +117,7 @@ fn handle_internal_linking(rt: &Runtime) {
             Some("add") => {
                 for mut to_entry in to {
                     if let Err(e) = to_entry.add_internal_link(&mut from) {
-                        trace_error(&e);
-                        exit(1);
+                        trace_error_exit(&e, 1);
                     }
                 }
             },
@@ -126,8 +125,7 @@ fn handle_internal_linking(rt: &Runtime) {
             Some("remove") => {
                 for mut to_entry in to {
                     if let Err(e) = to_entry.remove_internal_link(&mut from) {
-                        trace_error(&e);
-                        exit(1);
+                        trace_error_exit(&e, 1);
                     }
                 }
             },
@@ -182,14 +180,11 @@ fn get_entry_by_name<'a>(rt: &'a Runtime, name: &str) -> Result<FileLockEntry<'a
 }
 
 fn handle_external_linking(rt: &Runtime) {
-    use libimagerror::trace::trace_error;
-
     let scmd       = rt.cli().subcommand_matches("external").unwrap();
     let entry_name = scmd.value_of("id").unwrap(); // enforced by clap
     let entry      = get_entry_by_name(rt, entry_name);
     if entry.is_err() {
-        trace_error(&entry.unwrap_err());
-        exit(1);
+        trace_error_exit(&entry.unwrap_err(), 1);
     }
     let mut entry = entry.unwrap();
 
@@ -226,9 +221,7 @@ fn add_link_to_entry(store: &Store, matches: &ArgMatches, entry: &mut FileLockEn
     let link = Url::parse(link);
     if link.is_err() {
         debug!("URL parsing error...");
-        trace_error(&link.unwrap_err());
-        debug!("Exiting");
-        exit(1);
+        trace_error_exit(&link.unwrap_err(), 1);
     }
     let link = link.unwrap();
 
@@ -246,8 +239,7 @@ fn remove_link_from_entry(store: &Store, matches: &ArgMatches, entry: &mut FileL
 
     let link = Url::parse(link);
     if link.is_err() {
-        trace_error(&link.unwrap_err());
-        exit(1);
+        trace_error_exit(&link.unwrap_err(), 1);
     }
     let link = link.unwrap();
 

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -65,7 +65,6 @@ fn main() {
 
 fn handle_internal_linking(rt: &Runtime) {
     use libimagentrylink::internal::InternalLinker;
-    use libimagerror::trace::trace_error;
 
     debug!("Handle internal linking call");
     let cmd = rt.cli().subcommand_matches("internal").unwrap();

--- a/imag-notes/src/main.rs
+++ b/imag-notes/src/main.rs
@@ -14,7 +14,7 @@ use libimagrt::edit::Edit;
 use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
 use libimagnotes::note::Note;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 
 mod ui;
 use ui::build_ui;
@@ -95,8 +95,7 @@ fn list(rt: &Runtime) {
 
     let iter = Note::all_notes(rt.store());
     if iter.is_err() {
-        trace_error(&iter.unwrap_err());
-        exit(1);
+        trace_error_exit(&iter.unwrap_err(), 1);
     }
 
     let mut iter = iter.unwrap()

--- a/imag-store/src/create.rs
+++ b/imag-store/src/create.rs
@@ -14,7 +14,7 @@ use libimagrt::runtime::Runtime;
 use libimagstore::store::Entry;
 use libimagstore::store::EntryHeader;
 use libimagstore::storeid::build_entry_path;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::trace_error_exit;
 
 use error::StoreError;
 use error::StoreErrorKind;
@@ -38,8 +38,7 @@ pub fn create(rt: &Runtime) {
 
             let path = build_entry_path(rt.store(), path.unwrap());
             if path.is_err() {
-                trace_error(&path.unwrap_err());
-                exit(1);
+                trace_error_exit(&path.unwrap_err(), 1);
             }
             let path = path.unwrap();
             debug!("path = {:?}", path);

--- a/imag-store/src/delete.rs
+++ b/imag-store/src/delete.rs
@@ -1,6 +1,6 @@
 use libimagstore::storeid::build_entry_path;
 use libimagrt::runtime::Runtime;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::trace_error_exit;
 
 pub fn delete(rt: &Runtime) {
     use std::process::exit;
@@ -12,8 +12,7 @@ pub fn delete(rt: &Runtime) {
                 .map(|id| {
                     let path = build_entry_path(rt.store(), id);
                     if path.is_err() {
-                        trace_error(&path.unwrap_err());
-                        exit(1);
+                        trace_error_exit(&path.unwrap_err(), 1);
                     }
                     let path = path.unwrap();
                     debug!("Deleting file at {:?}", id);

--- a/imag-store/src/get.rs
+++ b/imag-store/src/get.rs
@@ -1,5 +1,3 @@
-use std::process::exit;
-
 use libimagstore::storeid::build_entry_path;
 use libimagrt::runtime::Runtime;
 use libimagerror::trace::{trace_error, trace_error_exit};

--- a/imag-store/src/get.rs
+++ b/imag-store/src/get.rs
@@ -2,7 +2,7 @@ use std::process::exit;
 
 use libimagstore::storeid::build_entry_path;
 use libimagrt::runtime::Runtime;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 
 use retrieve::print_entry;
 
@@ -14,8 +14,7 @@ pub fn get(rt: &Runtime) {
                 .map(|id| {
                     let path = build_entry_path(rt.store(), id);
                     if path.is_err() {
-                        trace_error(&path.unwrap_err());
-                        exit(1);
+                        trace_error_exit(&path.unwrap_err(), 1);
                     }
                     let path = path.unwrap();
                     debug!("path = {:?}", path);

--- a/imag-store/src/retrieve.rs
+++ b/imag-store/src/retrieve.rs
@@ -6,7 +6,7 @@ use toml::Value;
 use libimagstore::store::FileLockEntry;
 use libimagstore::storeid::build_entry_path;
 use libimagrt::runtime::Runtime;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 
 pub fn retrieve(rt: &Runtime) {
     rt.cli()
@@ -16,8 +16,7 @@ pub fn retrieve(rt: &Runtime) {
                 .map(|id| {
                     let path = build_entry_path(rt.store(), id);
                     if path.is_err() {
-                        trace_error(&path.unwrap_err());
-                        exit(1);
+                        trace_error_exit(&path.unwrap_err(), 1);
                     }
                     let path = path.unwrap();
                     debug!("path = {:?}", path);

--- a/imag-store/src/retrieve.rs
+++ b/imag-store/src/retrieve.rs
@@ -1,5 +1,3 @@
-use std::process::exit;
-
 use clap::ArgMatches;
 use toml::Value;
 

--- a/imag-store/src/update.rs
+++ b/imag-store/src/update.rs
@@ -3,7 +3,7 @@ use std::process::exit;
 
 use libimagrt::runtime::Runtime;
 use libimagstore::storeid::build_entry_path;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::trace_error_exit;
 
 use util::build_toml_header;
 
@@ -15,8 +15,7 @@ pub fn update(rt: &Runtime) {
                 .map(|id| {
                     let path = build_entry_path(rt.store(), id);
                     if path.is_err() {
-                        trace_error(&path.unwrap_err());
-                        exit(1);
+                        trace_error_exit(&path.unwrap_err(), 1);
                     }
                     let path = path.unwrap();
 

--- a/imag-store/src/update.rs
+++ b/imag-store/src/update.rs
@@ -1,5 +1,4 @@
 use std::ops::DerefMut;
-use std::process::exit;
 
 use libimagrt::runtime::Runtime;
 use libimagstore::storeid::build_entry_path;

--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -16,7 +16,7 @@ use libimagrt::setup::generate_runtime_setup;
 use libimagentrytag::tagable::Tagable;
 use libimagentrytag::tag::Tag;
 use libimagstore::storeid::build_entry_path;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 use libimagentrytag::ui::{get_add_tags, get_remove_tags};
 
 mod ui;
@@ -53,10 +53,7 @@ fn main() {
 fn alter(rt: &Runtime, id: &str, add: Option<Vec<Tag>>, rem: Option<Vec<Tag>>) {
     let path = {
         match build_entry_path(rt.store(), id) {
-            Err(e) => {
-                trace_error(&e);
-                exit(1);
-            },
+            Err(e) => trace_error_exit(&e, 1),
             Ok(s) => s,
         }
     };
@@ -97,10 +94,7 @@ fn alter(rt: &Runtime, id: &str, add: Option<Vec<Tag>>, rem: Option<Vec<Tag>>) {
 fn list(id: &str, rt: &Runtime) {
     let path = {
         match build_entry_path(rt.store(), id) {
-            Err(e) => {
-                trace_error(&e);
-                exit(1);
-            },
+            Err(e) => trace_error_exit(&e, 1),
             Ok(s) => s,
         }
     };
@@ -116,8 +110,7 @@ fn list(id: &str, rt: &Runtime) {
         Err(e) => {
             debug!("Could not get '{:?}' => {:?}", id, path);
             warn!("Could not get entry '{}'", id);
-            trace_error(&e);
-            exit(1);
+            trace_error_exit(&e, 1);
         },
     };
 
@@ -135,8 +128,7 @@ fn list(id: &str, rt: &Runtime) {
 
     let tags = entry.get_tags();
     if tags.is_err() {
-        trace_error(&tags.unwrap_err());
-        exit(1);
+        trace_error_exit(&tags.unwrap_err(), 1);
     }
     let tags = tags.unwrap();
 

--- a/imag-view/src/main.rs
+++ b/imag-view/src/main.rs
@@ -30,7 +30,7 @@ use std::process::exit;
 use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
 use libimagstore::store::FileLockEntry;
-use libimagerror::trace::trace_error;
+use libimagerror::trace::{trace_error, trace_error_exit};
 
 mod error;
 mod ui;
@@ -54,8 +54,7 @@ fn main() {
 
     if rt.cli().is_present("versions") {
         if let Err(e) = view_versions_of(entry_id, &rt) {
-            trace_error(&e);
-            exit(1); // we can afford not-executing destructors here
+            trace_error_exit(&e, 1);
         }
     } else {
         let entry_version   = rt.cli().value_of("version");
@@ -93,8 +92,7 @@ fn main() {
 
         let entry = load_entry(entry_id, entry_version, &rt);
         if entry.is_err() {
-            trace_error(&entry.unwrap_err());
-            exit(1); // we can afford not-executing destructors here
+            trace_error_exit(&entry.unwrap_err(), 1);
         }
         let entry = entry.unwrap();
 

--- a/libimagerror/src/trace.rs
+++ b/libimagerror/src/trace.rs
@@ -28,7 +28,7 @@ pub fn trace_error(e: &Error) {
 
 /// Convenience function: calls `trace_error()` with `e` and afterwards `std::process::exit()`
 /// with `code`
-pub fn trace_error_exit(e: &Error, code: i32) {
+pub fn trace_error_exit(e: &Error, code: i32) -> ! {
     use std::process::exit;
 
     debug!("Tracing error...");

--- a/libimagerror/src/trace.rs
+++ b/libimagerror/src/trace.rs
@@ -26,6 +26,15 @@ pub fn trace_error(e: &Error) {
     write!(stderr(), "\n").ok();
 }
 
+/// Convenience function: calls `trace_error()` with `e` and afterwards `std::process::exit()`
+/// with `code`
+pub fn trace_error_exit(e: &Error, code: i32) {
+    use std::process::exit;
+
+    trace_error(e);
+    exit(code);
+}
+
 /// Print an Error type and its cause recursively, but only `max` levels
 ///
 /// Output is the same as for `trace_error()`, though there are only `max` levels printed.

--- a/libimagerror/src/trace.rs
+++ b/libimagerror/src/trace.rs
@@ -31,7 +31,9 @@ pub fn trace_error(e: &Error) {
 pub fn trace_error_exit(e: &Error, code: i32) {
     use std::process::exit;
 
+    debug!("Tracing error...");
     trace_error(e);
+    debug!("Calling exit()");
     exit(code);
 }
 


### PR DESCRIPTION
Could be nice to write some binaries where we often use this, actually.

Some commits will follow where I clean up things.