### PR TITLE
Fix flags for root command not working; Added in debug forwarding

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -158,15 +158,15 @@ fn main() {
         },
 
         s => {
-            let subcommand_args = &find_args(s)[..];
+            let mut subcommand_args = find_args(s);
             if is_debug {
-                subcommand_args.push("--debug");
+                subcommand_args.push(String::from("--debug"));
             }
             match Command::new(format!("imag-{}", s))
                 .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
-                .args(subcommand_args)
+                .args(&subcommand_args[..])
                 .spawn()
                 .and_then(|mut handle| handle.wait())
             {

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -166,7 +166,7 @@ fn main() {
         s => {
             let mut subcommand_args = find_args(s);
             if is_debug && subcommand_args.iter().find(is_debug_flag).is_none() {
-                subcommand_args.push(String::from(DBG_FLAG));
+                subcommand_args.insert(0, String::from(DBG_FLAG));
             }
             match Command::new(format!("imag-{}", s))
                 .stdin(Stdio::inherit())

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
 
         s => {
             let mut subcommand_args = find_args(s);
-            if is_debug && subcommand_args.filter(|x| x == "debug").count() == 0 {
+            if is_debug && subcommand_args.iter().find(|x| *x == "debug").is_none() {
                 subcommand_args.push(String::from("--debug"));
             }
             match Command::new(format!("imag-{}", s))

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
 
         s => {
             let mut subcommand_args = find_args(s);
-            if is_debug {
+            if is_debug && subcommand_args.filter(|x| x == "debug").count() == 0 {
                 subcommand_args.push(String::from("--debug"));
             }
             match Command::new(format!("imag-{}", s))

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
 
         s => {
             let mut subcommand_args = find_args(s);
-            if is_debug && subcommand_args.iter().find(|x| *x == "debug").is_none() {
+            if is_debug && subcommand_args.iter().find(|x| *x == "--debug").is_none() {
                 subcommand_args.push(String::from("--debug"));
             }
             match Command::new(format!("imag-{}", s))

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -125,6 +125,7 @@ fn main() {
             },
         },
     };
+    let is_debug = env::args().skip(1).filter(|x| x == "--debug").next().is_some();
 
     match &first_arg[..] {
         "--help" | "-h" => {
@@ -157,11 +158,15 @@ fn main() {
         },
 
         s => {
+            let subcommand_args = &find_args(s)[..];
+            if is_debug {
+                subcommand_args.push("--debug");
+            }
             match Command::new(format!("imag-{}", s))
                 .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
-                .args(&find_args(s)[..])
+                .args(subcommand_args)
                 .spawn()
                 .and_then(|mut handle| handle.wait())
             {

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -11,6 +11,8 @@ use std::io::ErrorKind;
 use walkdir::WalkDir;
 use crossbeam::*;
 
+const DBG_FLAG: &'static str = "--debug";
+
 fn help(cmds: Vec<String>) {
     println!(r#"
 
@@ -103,6 +105,10 @@ fn find_flag() -> Option<String> {
     env::args().skip(1).filter(|x| x.starts_with("-")).next()
 }
 
+fn is_debug_flag<T: AsRef<str>>(ref s: &T) -> bool {
+    s.as_ref() == DBG_FLAG
+}
+
 fn find_args(command: &str) -> Vec<String> {
     env::args()
         .skip(1)
@@ -125,7 +131,7 @@ fn main() {
             },
         },
     };
-    let is_debug = env::args().skip(1).filter(|x| x == "--debug").next().is_some();
+    let is_debug = env::args().skip(1).find(is_debug_flag).is_some();
 
     match &first_arg[..] {
         "--help" | "-h" => {
@@ -159,8 +165,8 @@ fn main() {
 
         s => {
             let mut subcommand_args = find_args(s);
-            if is_debug && subcommand_args.iter().find(|x| *x == "--debug").is_none() {
-                subcommand_args.push(String::from("--debug"));
+            if is_debug && subcommand_args.iter().find(is_debug_flag).is_none() {
+                subcommand_args.push(String::from(DBG_FLAG));
             }
             match Command::new(format!("imag-{}", s))
                 .stdin(Stdio::inherit())

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -99,6 +99,10 @@ fn find_command() -> Option<String> {
     env::args().skip(1).filter(|x| !x.starts_with("-")).next()
 }
 
+fn find_flag() -> Option<String> {
+    env::args().skip(1).filter(|x| x.starts_with("-")).next()
+}
+
 fn find_args(command: &str) -> Vec<String> {
     env::args()
         .skip(1)
@@ -113,9 +117,12 @@ fn main() {
     let _         = args.next();
     let first_arg = match find_command() {
         Some(s) => s,
-        None    => {
-            help(commands);
-            exit(0);
+        None    => match find_flag() {
+            Some(s) => s,
+            None => {
+                help(commands);
+                exit(0);
+            },
         },
     };
 


### PR DESCRIPTION
Previously, flags like `--version` were ignored, and would always display the help. This fixes that and also adds in the ability to write `imag --debug foo`.