### PR TITLE
Remove dash from command listing

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -78,7 +78,7 @@ fn get_commands() -> Vec<String> {
                         .filter_map(|path| {
                            path.file_name()
                                .to_str()
-                               .map(String::from)
+                               .and_then(|s| s.splitn(2, "-").nth(1).map(|s| format!("imag {}", s)))
                         })
                         .collect()
                 })


### PR DESCRIPTION
With this patch, we list "imag counter" instead of "imag-counter" in the
help output.