### PR TITLE
Fix panic on unwrap()

### DIFF
--- a/imag-notes/src/ui.rs
+++ b/imag-notes/src/ui.rs
@@ -46,9 +46,6 @@ pub fn build_ui<'a>(app: App<'a, 'a>) -> App<'a, 'a> {
                         .value_name("NAME"))
 
                    .arg(tag_argument())
-                   .group(ArgGroup::with_name("editargs")
-                          .args(&[tag_argument_name(), "name"])
-                          .required(true))
                    )
 
         .subcommand(SubCommand::with_name("list")


### PR DESCRIPTION
Surprisingly, the ArgGroup feature of clap (which was applied in a wrong
way here anyways) caused the "name" Arg to be inaccessible. I don't know
why, but that's it.

Removing the group fixes the issue.

---

Closes #461 