### PR TITLE
libimagentrymarkdown: Deny warnings

### DIFF
--- a/libimagentrymarkdown/src/lib.rs
+++ b/libimagentrymarkdown/src/lib.rs
@@ -1,3 +1,17 @@
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate log;
 extern crate crossbeam;
 extern crate hoedown;


### PR DESCRIPTION
Number 2 in a series of seven branches addressing #507.