### PR TITLE
libimagentryselect: Deny warnings

### DIFF
--- a/libimagentryselect/src/lib.rs
+++ b/libimagentryselect/src/lib.rs
@@ -1,3 +1,17 @@
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 extern crate clap;
 extern crate log;
 extern crate interactor;


### PR DESCRIPTION
Number 3 in a series of seven branches addressing #507.