### PR TITLE
libimagerror: Deny warnings

### DIFF
--- a/libimagerror/src/error_gen.rs
+++ b/libimagerror/src/error_gen.rs
@@ -331,7 +331,7 @@ mod test {
     #[test]
     fn test_error_kind_mapping() {
         use std::io::{Error, ErrorKind};
-        use self::error::{OkOrErr, MapErrInto};
+        use self::error::MapErrInto;
         use self::error::TestErrorKind;
 
         let err : Result<(), _> = Err(Error::new(ErrorKind::Other, ""));
@@ -349,7 +349,7 @@ mod test {
     #[test]
     fn test_error_kind_double_mapping() {
         use std::io::{Error, ErrorKind};
-        use self::error::{OkOrErr, MapErrInto};
+        use self::error::MapErrInto;
         use self::error::TestErrorKind;
 
         let err : Result<(), _> = Err(Error::new(ErrorKind::Other, ""));
@@ -373,7 +373,7 @@ mod test {
 
     #[test]
     fn test_error_option_good() {
-        use self::error::{OkOrErr, MapErrInto};
+        use self::error::OkOrErr;
         use self::error::TestErrorKind;
 
         let something = Some(1);
@@ -385,7 +385,7 @@ mod test {
 
     #[test]
     fn test_error_option_bad() {
-        use self::error::{OkOrErr, MapErrInto};
+        use self::error::OkOrErr;
         use self::error::TestErrorKind;
 
         let something : Option<i32> = None;

--- a/libimagerror/src/lib.rs
+++ b/libimagerror/src/lib.rs
@@ -1,3 +1,17 @@
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate log;
 extern crate ansi_term;
 


### PR DESCRIPTION
Number 4 in a series of seven branches addressing #507.