### PR TITLE
Imag (library) documentation

### DIFF
--- a/.imag-documentation/Cargo.toml
+++ b/.imag-documentation/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+name = "imag-documentation"
+version = "0.2.0"
+authors = ["Matthias Beyer <mail@beyermatthias.de>"]
+
+[dependencies]
+
+[dependencies.libimagbookmark]
+path = "../libimagbookmark"
+
+[dependencies.libimagcounter]
+path = "../libimagcounter"
+
+[dependencies.libimagdiary]
+path = "../libimagdiary"
+
+[dependencies.libimagentryfilter]
+path = "../libimagentryfilter"
+
+[dependencies.libimagentrylink]
+path = "../libimagentrylink"
+
+[dependencies.libimagentrylist]
+path = "../libimagentrylist"
+
+[dependencies.libimagentrymarkdown]
+path = "../libimagentrymarkdown"
+
+[dependencies.libimagentryselect]
+path = "../libimagentryselect"
+
+[dependencies.libimagentrytag]
+path = "../libimagentrytag"
+
+[dependencies.libimagentryview]
+path = "../libimagentryview"
+
+[dependencies.libimagerror]
+path = "../libimagerror"
+
+[dependencies.libimaginteraction]
+path = "../libimaginteraction"
+
+[dependencies.libimagnotes]
+path = "../libimagnotes"
+
+[dependencies.libimagref]
+path = "../libimagref"
+
+[dependencies.libimagrt]
+path = "../libimagrt"
+
+[dependencies.libimagstore]
+path = "../libimagstore"
+
+[dependencies.libimagstorestdhook]
+path = "../libimagstorestdhook"
+
+[dependencies.libimagtimeui]
+path = "../libimagtimeui"
+
+[dependencies.libimagutil]
+path = "../libimagutil"
+

--- a/.imag-documentation/src/lib.rs
+++ b/.imag-documentation/src/lib.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 toml = $@/Cargo.toml
 bin = $@/target/debug/$@
 
+doc-crate-toml=./.imag-documentation/Cargo.toml
+
 default: all
 
 .PHONY: clean
@@ -10,6 +12,9 @@ all: imag-counter imag-link imag-notes imag-store imag-tag imag-view
 imag-%: prep
 	cargo build --manifest-path $(toml)
 	cp $(bin) out/
+
+lib-doc:
+	cargo build --manifest-path $(doc-crate-toml)
 
 prep:
 	mkdir -p out/


### PR DESCRIPTION
Adds a meta-crate (hidden in a dot-directory) which depends on all `libimag*` crates, so we can build the complete library documentation from a single crate.

Closes #472 