### PR TITLE
Add travis setup for IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,11 @@ after_success:
 notifications:
     email:
         on_success: never
+    irc:
+        channels:
+            - "chat.freenode.net#imag"
+        template:
+            - "%{repository_name} (%{branch} @ %{commit} by %{author}): %{result}"
 
 env:
     global:


### PR DESCRIPTION
As we now have a IRC channel registered with freenode, we could use the travis IRC bot to notify on builds! :smile: 