### PR TITLE
Libimagstore/remove storeid from pathbuf

### DIFF
--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -840,7 +840,7 @@ impl Drop for Store {
      * TODO: Unlock them
      */
     fn drop(&mut self) {
-        let store_id = StoreId::from(self.location.clone());
+        let store_id = StoreId(self.location.clone());
         if let Err(e) = self.execute_hooks_for_id(self.store_unload_aspects.clone(), &store_id) {
             debug!("Store-load hooks execution failed. Cannot create store object.");
             warn!("Store Unload Hook error: {:?}", e);

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -61,7 +61,7 @@ struct StoreEntry {
 }
 
 pub enum StoreObject {
-    Id(StoreId),
+    Id(PathBuf),
     Collection(PathBuf),
 }
 
@@ -96,7 +96,7 @@ impl Iterator for Walk {
                 Ok(next) => if next.file_type().is_dir() {
                                 return Some(StoreObject::Collection(next.path().to_path_buf()))
                             } else if next.file_type().is_file() {
-                                return Some(StoreObject::Id(next.path().to_path_buf().into()))
+                                return Some(StoreObject::Id(next.path().to_path_buf()))
                             },
                 Err(e) => {
                     warn!("Error in Walker");
@@ -1500,6 +1500,7 @@ impl Entry {
 mod glob_store_iter {
     use std::fmt::{Debug, Formatter};
     use std::fmt::Error as FmtError;
+    use std::path::PathBuf;
     use glob::Paths;
     use storeid::StoreId;
     use storeid::StoreIdIterator;
@@ -1535,9 +1536,9 @@ mod glob_store_iter {
     }
 
     impl Iterator for GlobStoreIdIterator {
-        type Item = StoreId;
+        type Item = PathBuf;
 
-        fn next(&mut self) -> Option<StoreId> {
+        fn next(&mut self) -> Option<PathBuf> {
             self.paths.next().and_then(|o| {
                 match o {
                     Ok(o) => Some(o),
@@ -1546,7 +1547,7 @@ mod glob_store_iter {
                         None
                     },
                 }
-            }).map(|p| StoreId(p))
+            })
         }
 
     }

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1546,7 +1546,7 @@ mod glob_store_iter {
                         None
                     },
                 }
-            }).map(|p| StoreId::from(p))
+            }).map(|p| StoreId(p))
         }
 
     }

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -167,7 +167,7 @@ macro_rules! module_entry_path_mod {
 }
 
 pub struct StoreIdIterator {
-    iter: Box<Iterator<Item = StoreId>>,
+    iter: Box<Iterator<Item = PathBuf>>,
 }
 
 impl Debug for StoreIdIterator {
@@ -180,7 +180,7 @@ impl Debug for StoreIdIterator {
 
 impl StoreIdIterator {
 
-    pub fn new(iter: Box<Iterator<Item = StoreId>>) -> StoreIdIterator {
+    pub fn new(iter: Box<Iterator<Item = PathBuf>>) -> StoreIdIterator {
         StoreIdIterator {
             iter: iter,
         }
@@ -189,9 +189,9 @@ impl StoreIdIterator {
 }
 
 impl Iterator for StoreIdIterator {
-    type Item = StoreId;
+    type Item = PathBuf;
 
-    fn next(&mut self) -> Option<StoreId> {
+    fn next(&mut self) -> Option<PathBuf> {
         self.iter.next()
     }
 

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -61,14 +61,6 @@ impl Deref for StoreId {
 
 }
 
-impl From<PathBuf> for StoreId {
-
-    fn from(pb: PathBuf) -> StoreId {
-        StoreId(pb)
-    }
-
-}
-
 impl AsRef<Path> for StoreId {
 
     fn as_ref(&self) -> &Path {

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -69,14 +69,6 @@ impl From<PathBuf> for StoreId {
 
 }
 
-impl From<String> for StoreId {
-
-    fn from(string: String) -> StoreId {
-        StoreId(string.into())
-    }
-
-}
-
 impl AsRef<Path> for StoreId {
 
     fn as_ref(&self) -> &Path {

--- a/libimagstore/src/storeid.rs
+++ b/libimagstore/src/storeid.rs
@@ -27,7 +27,7 @@ impl StoreId {
             let mut new_id = store.path().clone();
             new_id.push(self);
             debug!("Created: '{:?}'", new_id);
-            StoreId::from(new_id)
+            StoreId(new_id)
         }
     }
 


### PR DESCRIPTION
This is an experiement.

I want to remove complexity from the `StoreId` type to see what builds break ... this could simplify the changes @TheNeikos wants to make.