### PR TITLE
Allow travis to fail beta, temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache: cargo
 matrix:
     allow_failures:
         - rust: nightly
+        - rust: beta
 
 before_install:
     - |


### PR DESCRIPTION
As said in https://github.com/matthiasbeyer/imag/pull/650 all we can do is wait - not really. We can also allow travis beta to fail.

This PR adds a patch that allows the travis job with the beta compiler to fail and _this patch should be reverted as soon as possible_.

But with this patch applied we can continue working on imag.