### PR TITLE
Disable nightly builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,8 @@ sudo: false
 language: rust
 rust:
 - beta
-- nightly
 - stable
 cache: cargo
-matrix:
-  allow_failures:
-  - rust: nightly
 before_install:
 - |
   c=$(git diff $(git merge-base master $TRAVIS_COMMIT)..$TRAVIS_COMMIT --name-only | cut -d "/" -f 1 | uniq)


### PR DESCRIPTION
Because they fail anyways... and I do not really care for nightly for imag, so we can disable it.