### PR TITLE
libimagutil: Add warn_exit() convenience helper

### DIFF
--- a/libimagutil/src/lib.rs
+++ b/libimagutil/src/lib.rs
@@ -24,4 +24,5 @@ pub mod ismatch;
 pub mod iter;
 pub mod key_value_split;
 pub mod variants;
+pub mod warn_exit;
 pub mod warn_result;

--- a/libimagutil/src/warn_exit.rs
+++ b/libimagutil/src/warn_exit.rs
@@ -1,0 +1,22 @@
+/// This function prints the string `s` via the `warn!()` macro and then exits with the code `code`
+/// as status.
+///
+/// Convenience function to be used in matches to remove one scope:
+///
+/// ```ignore
+/// use libimagutil::warn_exit::warn_exit;
+///
+/// let r: Result<i32, i32> = Err(1);
+/// match r {
+///     Err(e) => warn_exit("Warning!", 42),
+///     Ok(num) => { /* ... */ }
+/// }
+/// ```
+///
+pub fn warn_exit(s: &str, code: i32) -> ! {
+    use std::process::exit;
+
+    warn!("{}", s);
+    exit(code);
+}
+


### PR DESCRIPTION
Can be helpful in some `imag-*` implementations.