### PR TITLE
Fix absolute StoreId specification in imag-store test

### DIFF
--- a/imag-store/tests/002-retrieve_test.sh
+++ b/imag-store/tests/002-retrieve_test.sh
@@ -23,7 +23,7 @@ test_retrieve_nothing() {
     imag-store create -p ${id} || { err "create failed"; return 1; }
 
     out "Going to test the retrieve functionality now"
-    local zero_out="$(retrieve --id ${id})"
+    local zero_out="$(retrieve --id ${id})" || return 1
     out "Retrieving for zero_out finished"
 
     if [[ ! -z "$zero_out" ]]; then
@@ -39,7 +39,7 @@ test_retrieve_content() {
 
     out "Going to test the retrieve functionality now"
 
-    local content_out="$(retrieve --id ${id} --content)"
+    local content_out="$(retrieve --id ${id} --content)" || return 1
     out "Retrieving for content_out finished"
 
     if [[ ! -z "$content_out" ]]; then

--- a/imag-store/tests/002-retrieve_test.sh
+++ b/imag-store/tests/002-retrieve_test.sh
@@ -23,7 +23,7 @@ test_retrieve_nothing() {
     imag-store create -p ${id} || { err "create failed"; return 1; }
 
     out "Going to test the retrieve functionality now"
-    local zero_out="$(retrieve --id /${id})"
+    local zero_out="$(retrieve --id ${id})"
     out "Retrieving for zero_out finished"
 
     if [[ ! -z "$zero_out" ]]; then
@@ -39,7 +39,7 @@ test_retrieve_content() {
 
     out "Going to test the retrieve functionality now"
 
-    local content_out="$(retrieve --id /${id} --content)"
+    local content_out="$(retrieve --id ${id} --content)"
     out "Retrieving for content_out finished"
 
     if [[ ! -z "$content_out" ]]; then


### PR DESCRIPTION
We missed them in #667 - why didn't the test suite fail.

@mario-kr I'd like you to investigate. Go to master (and, if this is already merged by then, revert this patch) and find out why the test suite did not fail.

And, of course, provide patches to fix the testing-suite.