### PR TITLE
Bin/clap debug

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -114,7 +114,7 @@ fn main() {
     let commands = get_commands();
     let helptext = help_text(commands);
     let app      = Runtime::get_default_cli_builder(appname, version, about)
-        .settings(&[AppSettings::AllowExternalSubcommands])
+        .settings(&[AppSettings::AllowExternalSubcommands, AppSettings::ArgRequiredElseHelp])
         .arg(Arg::with_name("version")
              .long("version")
              .takes_value(false)

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -170,7 +170,11 @@ fn main() {
 
     match matches.subcommand() {
         (subcommand, Some(scmd)) => {
-            let subcommand_args : Vec<&str> = scmd.values_of("").unwrap().collect();
+            debug!("Calling with subcommand: {}", subcommand);
+            let subcommand_args : Vec<&str> = match scmd.values_of("") {
+                Some(values) => values.collect(),
+                None => Vec::new()
+            };
             debug!("Calling 'imag-{}' with args: {:?}", subcommand, subcommand_args);
 
             match Command::new(format!("imag-{}", subcommand))

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
     if matches.is_present("versions") {
         debug!("Showing versions");
         let mut result = vec![];
-        for command in get_commands().iter() {
+        for command in commands.iter() {
             result.push(crossbeam::scope(|scope| {
                 scope.spawn(|| {
                     let v = Command::new(format!("imag-{}",command)).arg("--version").output();
@@ -186,7 +186,7 @@ fn main() {
             };
             
             // Typos happen, so check if the given subcommand is one found in $PATH
-            if !commands.clone().contains(&String::from(subcommand)) {
+            if !commands.contains(&String::from(subcommand)) {
                 println!("No such command: 'imag-{}'", subcommand);
                 println!("See 'imag --help' for available subcommands");
                 exit(2);

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -189,7 +189,7 @@ fn main() {
                     if !exit_status.success() {
                         debug!("{} exited with non-zero exit code: {:?}", subcommand, exit_status);
                         println!("{} exited with non-zero exit code", subcommand);
-                        exit(exit_status.code().unwrap_or(42));
+                        exit(exit_status.code().unwrap_or(1));
                     }
                     debug!("Successful exit!");
                 },
@@ -208,7 +208,7 @@ fn main() {
                         },
                         _ => {
                             println!("Error spawning: {:?}", e);
-                            exit(1337);
+                            exit(1);
                         }
                     }
                 }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -169,7 +169,8 @@ fn main() {
         }
 
         for versionstring in result.into_iter().map(|handle| handle.join()) {
-            print!("{}", versionstring);
+            // The amount of newlines may differ depending on the subprocess
+            println!("{}", versionstring.trim());
         }
     }
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
         for command in get_commands().iter() {
             result.push(crossbeam::scope(|scope| {
                 scope.spawn(|| {
-                    let v = Command::new(command).arg("--version").output();
+                    let v = Command::new(format!("imag-{}",command)).arg("--version").output();
                     match v {
                         Ok(v) => match String::from_utf8(v.stdout) {
                             Ok(s) => format!("{} -> {}", command, s),

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -175,6 +175,13 @@ fn main() {
                 Some(values) => values.collect(),
                 None => Vec::new()
             };
+            
+            if !get_commands().contains(&String::from(subcommand)) {
+                println!("No such command: 'imag-{}'", subcommand);
+                println!("See 'imag --help' for available subcommands");
+                exit(2);
+            }
+    
             debug!("Calling 'imag-{}' with args: {:?}", subcommand, subcommand_args);
 
             match Command::new(format!("imag-{}", subcommand))
@@ -198,6 +205,8 @@ fn main() {
                     debug!("Error calling the subcommand");
                     match e.kind() {
                         ErrorKind::NotFound => {
+                            // With the check above, this absolutely should not happen.
+                            // Keeping it to be safe
                             println!("No such command: 'imag-{}'", subcommand);
                             println!("See 'imag --help' for available subcommands");
                             exit(2);

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
                     let v = Command::new(format!("imag-{}",command)).arg("--version").output();
                     match v {
                         Ok(v) => match String::from_utf8(v.stdout) {
-                            Ok(s) => format!("{} -> {}", command, s),
+                            Ok(s) => format!("{:10} -> {}", command, s),
                             Err(e) => format!("Failed calling {} -> {:?}", command, e),
                         },
                         Err(e) => format!("Failed calling {} -> {:?}", command, e),
@@ -169,7 +169,7 @@ fn main() {
         }
 
         for versionstring in result.into_iter().map(|handle| handle.join()) {
-            println!("{}", versionstring);
+            print!("{}", versionstring);
         }
     }
 


### PR DESCRIPTION
This PR contains some fixes, and some misc stuff:
* There was a panic when no arguments at all or no additional arguments to the subcommand were given
* Exit codes were probably decided on while the person was bored
* It wasn't checked if subcommand existed before constructing a child-process, which would then fail because the required executable wouldnt exist.
* the `unreachable!()` at the end seemed to have been reachable - by passing no subcommand, but a argument which wouldnt exit (in this case, `--versions`)
* Some comments were added (The whole file was nearly a comment-free zone)
* `--versions` Only produced error output, because it tried to call `imag-<>` without the `imag-`
* `--versions` output was prettied a tiny little bit (out of all the commits I consider this one to be optional, so I wouldnt mind reverting it)