### PR TITLE
Add newline before header

### DIFF
--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1440,7 +1440,7 @@ impl Entry {
     }
 
     pub fn to_str(&self) -> String {
-        format!("---{header}---\n{content}",
+        format!("---\n{header}---\n{content}",
                 header  = ::toml::encode_str(&self.header.header),
                 content = self.content)
     }


### PR DESCRIPTION
The lastest release of the `toml-rs` crate (2.1) removes leading spaces
before arrays and tables, causing our tests to fail.

This fixes it.

---

Related: https://github.com/alexcrichton/toml-rs/issues/113