### PR TITLE
libimagstore/store-tests: erroring hooks

### DIFF
--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -2372,36 +2372,36 @@ mod store_tests {
 #[cfg(test)]
 mod store_hook_tests {
 
-    mod succeeding_hook {
+    mod test_hook {
         use hook::Hook;
         use hook::accessor::HookDataAccessor;
         use hook::accessor::HookDataAccessorProvider;
         use hook::position::HookPosition;
 
-        use self::accessor::SucceedingHookAccessor as DHA;
+        use self::accessor::TestHookAccessor as DHA;
 
         use toml::Value;
 
         #[derive(Debug)]
-        pub struct SucceedingHook {
+        pub struct TestHook {
             position: HookPosition,
             accessor: DHA,
         }
 
-        impl SucceedingHook {
+        impl TestHook {
 
-            pub fn new(pos: HookPosition) -> SucceedingHook {
-                SucceedingHook { position: pos.clone(), accessor: DHA::new(pos) }
+            pub fn new(pos: HookPosition) -> TestHook {
+                TestHook { position: pos.clone(), accessor: DHA::new(pos) }
             }
 
         }
 
-        impl Hook for SucceedingHook {
+        impl Hook for TestHook {
             fn name(&self) -> &'static str { "testhook_succeeding" }
             fn set_config(&mut self, _: &Value) { }
         }
 
-        impl HookDataAccessorProvider for SucceedingHook {
+        impl HookDataAccessorProvider for TestHook {
 
             fn accessor(&self) -> HookDataAccessor {
                 use hook::position::HookPosition as HP;
@@ -2432,17 +2432,17 @@ mod store_hook_tests {
             use storeid::StoreId;
 
             #[derive(Debug)]
-            pub struct SucceedingHookAccessor(HookPosition);
+            pub struct TestHookAccessor(HookPosition);
 
-            impl SucceedingHookAccessor {
+            impl TestHookAccessor {
 
-                pub fn new(position: HookPosition) -> SucceedingHookAccessor {
-                    SucceedingHookAccessor(position)
+                pub fn new(position: HookPosition) -> TestHookAccessor {
+                    TestHookAccessor(position)
                 }
 
             }
 
-            impl StoreIdAccessor for SucceedingHookAccessor {
+            impl StoreIdAccessor for TestHookAccessor {
 
                 fn access(&self, id: &StoreId) -> HookResult<()> {
                     Ok(())
@@ -2450,7 +2450,7 @@ mod store_hook_tests {
 
             }
 
-            impl MutableHookDataAccessor for SucceedingHookAccessor {
+            impl MutableHookDataAccessor for TestHookAccessor {
 
                 fn access_mut(&self, fle: &mut FileLockEntry) -> HookResult<()> {
                     Ok(())
@@ -2458,7 +2458,7 @@ mod store_hook_tests {
 
             }
 
-            impl NonMutableHookDataAccessor for SucceedingHookAccessor {
+            impl NonMutableHookDataAccessor for TestHookAccessor {
 
                 fn access(&self, fle: &FileLockEntry) -> HookResult<()> {
                     Ok(())
@@ -2476,7 +2476,7 @@ mod store_hook_tests {
     use storeid::StoreId;
     use store::Store;
 
-    use self::succeeding_hook::SucceedingHook;
+    use self::test_hook::TestHook;
 
     fn get_store_with_config() -> Store {
         use toml::Parser;
@@ -2514,7 +2514,7 @@ aspect = "test"
     fn test_pre_create() {
         let mut store = get_store_with_config();
         let pos       = HP::PreCreate;
-        let hook      = SucceedingHook::new(pos.clone());
+        let hook      = TestHook::new(pos.clone());
 
         assert!(store.register_hook(pos, "test", Box::new(hook)).map_err(|e| println!("{:?}", e)).is_ok());
 


### PR DESCRIPTION
Erroring-Hook-tests for `libimagstore`.

Not ready yet and should also be rebased after #761 is merged.