### PR TITLE
Warning cleanup

### DIFF
--- a/imag-bookmark/src/main.rs
+++ b/imag-bookmark/src/main.rs
@@ -69,7 +69,7 @@ fn add(rt: &Runtime) {
     BookmarkCollection::get(rt.store(), coll)
         .map(|mut collection| {
             for url in scmd.values_of("urls").unwrap() { // enforced by clap
-                collection.add_link(BookmarkLink::from(url)).map_err(|e| trace_error(&e));
+                collection.add_link(BookmarkLink::from(url)).map_err(|e| trace_error(&e)).ok();
             }
         });
     info!("Ready");
@@ -115,7 +115,8 @@ fn list(rt: &Runtime) {
                 },
                 Err(e) => trace_error_exit(&e, 1),
             }
-        });
+        })
+        .ok();
     info!("Ready");
 }
 
@@ -126,9 +127,10 @@ fn remove(rt: &Runtime) {
     BookmarkCollection::get(rt.store(), coll)
         .map(|mut collection| {
             for url in scmd.values_of("urls").unwrap() { // enforced by clap
-                collection.remove_link(BookmarkLink::from(url)).map_err(|e| trace_error(&e));
+                collection.remove_link(BookmarkLink::from(url)).map_err(|e| trace_error(&e)).ok();
             }
-        });
+        })
+        .ok();
     info!("Ready");
 }
 

--- a/imag-bookmark/src/main.rs
+++ b/imag-bookmark/src/main.rs
@@ -30,8 +30,6 @@ extern crate libimagutil;
 
 use std::process::exit;
 
-use libimagentrytag::ui::{get_add_tags, get_remove_tags};
-use libimagentrylink::internal::Link;
 use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
 use libimagbookmark::collection::BookmarkCollection;

--- a/imag-bookmark/src/main.rs
+++ b/imag-bookmark/src/main.rs
@@ -17,6 +17,21 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 extern crate clap;
 #[macro_use] extern crate log;
 #[macro_use] extern crate version;

--- a/imag-ref/src/main.rs
+++ b/imag-ref/src/main.rs
@@ -81,8 +81,6 @@ fn add(rt: &Runtime) {
 }
 
 fn remove(rt: &Runtime) {
-    use libimagref::error::RefErrorKind;
-    use libimagerror::into::IntoError;
     use libimaginteraction::ask::ask_bool;
 
     let cmd  = rt.cli().subcommand_matches("remove").unwrap();
@@ -102,10 +100,8 @@ fn remove(rt: &Runtime) {
 
 fn list(rt: &Runtime) {
     use std::process::exit;
-    use std::ops::Deref;
 
     use libimagentrylist::lister::Lister;
-    use libimagentrylist::listers::core::CoreLister;
     use libimagref::lister::RefLister;
 
     let cmd                      = rt.cli().subcommand_matches("list").unwrap();

--- a/imag-ref/src/main.rs
+++ b/imag-ref/src/main.rs
@@ -131,6 +131,7 @@ fn list(rt: &Runtime) {
         .check_changed(do_check_changed)
         .check_changed_content(do_check_changed_content)
         .check_changed_permiss(do_check_changed_permiss)
-        .list(iter.map(|e| e.into()));
+        .list(iter.map(|e| e.into()))
+        .ok();
 }
 

--- a/imag-ref/src/main.rs
+++ b/imag-ref/src/main.rs
@@ -17,6 +17,21 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate log;
 #[macro_use] extern crate version;
 extern crate semver;

--- a/libimagref/src/lister.rs
+++ b/libimagref/src/lister.rs
@@ -82,20 +82,6 @@ impl Default for RefLister {
     }
 }
 
-fn list_fn(e: &Entry) -> String {
-    let stored_hash = match e.get_header().read("ref.content_hash") {
-        Ok(Some(Value::String(s))) => s.clone(),
-        _                          => String::from("<Error: Could not read stored hash>"),
-    };
-
-    let filepath = match e.get_header().read("ref.path") {
-        Ok(Some(Value::String(ref s))) => s.clone(),
-        _ => String::from("<Error: Could not read file path>"),
-    };
-
-    format!("Ref({} -> {})", stored_hash, filepath)
-}
-
 impl Lister for RefLister {
 
     fn list<'b, I: Iterator<Item = FileLockEntry<'b>>>(&self, entries: I) -> Result<()> {

--- a/libimagref/src/lister.rs
+++ b/libimagref/src/lister.rs
@@ -190,7 +190,7 @@ fn check_changed_content(r: &Ref) -> bool {
     }
 }
 
-fn check_changed_permiss(r: &Ref) -> bool {
+fn check_changed_permiss(_: &Ref) -> bool {
     warn!("Permission changes tracking not supported yet.");
     false
 }

--- a/libimagref/src/lister.rs
+++ b/libimagref/src/lister.rs
@@ -21,12 +21,9 @@ use std::default::Default;
 use std::io::stdout;
 use std::io::Write;
 
-use toml::Value;
-
 use libimagentrylist::lister::Lister;
 use libimagentrylist::result::Result;
 use libimagerror::trace::trace_error;
-use libimagstore::store::Entry;
 use libimagstore::store::FileLockEntry;
 use libimagerror::into::IntoError;
 use libimagentrylist::error::ListErrorKind as LEK;

--- a/libimagref/src/reference.rs
+++ b/libimagref/src/reference.rs
@@ -169,13 +169,13 @@ impl<'a> Ref<'a> {
                     match can.to_str().map(String::from) {
                         // UTF convert error in PathBuf::to_str(),
                         None      => Err(REK::PathUTF8Error.into_error()),
-                        Some(can) => Ok((file, opt_conhash, opt_perm, can, path_hash))
+                        Some(can) => Ok((opt_conhash, opt_perm, can, path_hash))
                     }
                 })
 
                 // and then we create the FileLockEntry in the Store
                 // and return (filelockentry, content hash, permissions, canonicalized path)
-                .and_then(|(file, opt_conhash, opt_perm, can, path_hash)| {
+                .and_then(|(opt_conhash, opt_perm, can, path_hash)| {
                     let fle = try!(store
                                    .create(ModuleEntryPath::new(path_hash))
                                    .map_err(Box::new)


### PR DESCRIPTION
Some small cleanup patches for various crates, so they do not pollute the travis output anymore.

Also enforce warnings = errors.