### PR TITLE
Add dep for pure nix build: which

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@ let
     openssl
     zlib
     cmake
+    which
   ];
 in
 


### PR DESCRIPTION
Missing in `default.nix`.