### PR TITLE
libimagentrylink: external linking iterator interface

### DIFF
--- a/imag-bookmark/src/main.rs
+++ b/imag-bookmark/src/main.rs
@@ -127,8 +127,11 @@ fn list(rt: &Runtime) {
             match collection.links() {
                 Ok(links) => {
                     debug!("Listing...");
-                    for (i, link) in links.iter().enumerate() {
-                        println!("{: >3}: {}", i, link);
+                    for (i, link) in links.enumerate() {
+                        match link {
+                            Ok(link) => println!("{: >3}: {}", i, link),
+                            Err(e)   => trace_error(&e)
+                        }
                     };
                     debug!("... ready with listing");
                 },

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -297,7 +297,10 @@ fn list_links_for_entry(store: &Store, entry: &mut FileLockEntry) {
     entry.get_external_links(store)
         .and_then(|links| {
             for (i, link) in links.enumerate() {
-                println!("{: <3}: {}", i, link);
+                match link {
+                    Ok(link) => println!("{: <3}: {}", i, link),
+                    Err(e)   => trace_error(&e),
+                }
             }
             Ok(())
         })

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -296,7 +296,7 @@ fn set_links_for_entry(store: &Store, matches: &ArgMatches, entry: &mut FileLock
 fn list_links_for_entry(store: &Store, entry: &mut FileLockEntry) {
     entry.get_external_links(store)
         .and_then(|links| {
-            for (i, link) in links.iter().enumerate() {
+            for (i, link) in links.enumerate() {
                 println!("{: <3}: {}", i, link);
             }
             Ok(())

--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -144,7 +144,7 @@ pub mod iter {
     /// false... and so on.
     ///
     /// As we can see, the operator between these two operants is `!(a ^ b)`.
-    struct ExternalFilterIter(LinkIter, bool);
+    pub struct ExternalFilterIter(LinkIter, bool);
 
     impl Iterator for ExternalFilterIter {
         type Item = Link;
@@ -160,6 +160,23 @@ pub mod iter {
             None
         }
     }
+
+    /// Helper trait to be implemented on `LinkIter` to select or deselect all external links
+    ///
+    /// # See also
+    ///
+    /// Also see `OnlyExternalIter` and `NoExternalIter` and the helper traits/functions
+    /// `OnlyInteralLinks`/`only_internal_links()` and `OnlyExternalLinks`/`only_external_links()`.
+    pub trait SelectExternal {
+        fn select_external_links(self, b: bool) -> ExternalFilterIter;
+    }
+
+    impl SelectExternal for LinkIter {
+        fn select_external_links(self, b: bool) -> ExternalFilterIter {
+            ExternalFilterIter(self, b)
+        }
+    }
+
 
     pub struct OnlyExternalIter(ExternalFilterIter);
 

--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -116,6 +116,13 @@ pub mod iter {
     //!
     //! Contains also helpers to filter iterators for external/internal links
     //!
+    //!
+    //! # Warning
+    //!
+    //! This module uses `internal::Link` as link type, so we operate on _store ids_ here.
+    //!
+    //! Not to confuse with `external::Link` which is a real `FileLockEntry` under the hood.
+    //!
 
     use libimagutil::debug_result::*;
     use libimagstore::store::Store;

--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -112,6 +112,11 @@ pub trait ExternalLinker : InternalLinker {
 }
 
 pub mod iter {
+    //! Iterator helpers for external linking stuff
+    //!
+    //! Contains also helpers to filter iterators for external/internal links
+    //!
+
     use libimagutil::debug_result::*;
     use libimagstore::store::Store;
 


### PR DESCRIPTION
Welcome to the first iteration (pun intended) on `Matzes Fun with Iterators`.

Today, we talk about filter iterators.

Filter iterators are a funny thing. For example, see this wonderful pull request, containing a load of different filter iterators, all based on one simple iterator containing some boolean logic at its very core.

This pull request is not ready yet, though. It will get some more commits and will utlimately contain a rewrite of the interface for the external linking traits, so they return iterators instead of vectors. How is that? Yeah, we like that; it is great!

That's it for todays episode on `Matzes Fun with Iterators - Filter iterators`. See how easily we had fun?