### PR TITLE
libimagentrylink/filter predicates

### DIFF
--- a/libimagentrylink/Cargo.toml
+++ b/libimagentrylink/Cargo.toml
@@ -22,6 +22,7 @@ url = "1.2"
 rust-crypto = "0.2"
 env_logger = "0.3"
 is-match = "0.1"
+filters = "0.1.1"
 
 [dependencies.libimagstore]
 path = "../libimagstore"

--- a/libimagentrylink/src/internal.rs
+++ b/libimagentrylink/src/internal.rs
@@ -17,9 +17,11 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-use std::collections::BTreeMap;
 #[cfg(test)]
 use std::path::PathBuf;
+
+use std::collections::BTreeMap;
+use std::cmp::Ordering;
 
 use libimagstore::storeid::StoreId;
 use libimagstore::storeid::IntoStoreId;
@@ -391,6 +393,7 @@ pub mod pred {
         //! for links
 
         use std::error::Error;
+        use std::cmp::Ordering;
 
         use filters::filter::Filter;
 
@@ -399,26 +402,20 @@ pub mod pred {
 
         use super::super::InternalLinker;
 
-        pub enum LinkCountOp {
-            LT,
-            EQ,
-            GT,
-        }
-
         pub struct FilterLinkCount {
-            op: LinkCountOp,
+            op: Ordering,
             n: usize,
             errfn: Box<Fn(&Error) -> bool>,
         }
 
         impl FilterLinkCount {
 
-            /// Construct a new FilterLinkCount object using the `LinkCountOp` as comperator and `n`
+            /// Construct a new FilterLinkCount object using the `Ordering` as comperator and `n`
             /// as righthandside of the comparison.
             ///
             /// If the retrieval of the internal links for the `Entry` failed, use the `errfn`
             /// function to decide whether the entry should be filtered out.
-            pub fn new(op: LinkCountOp, n: usize, errfn: Box<Fn(&Error) -> bool>) -> FilterLinkCount {
+            pub fn new(op: Ordering, n: usize, errfn: Box<Fn(&Error) -> bool>) -> FilterLinkCount {
                 FilterLinkCount {
                     op: op,
                     n: n,
@@ -431,11 +428,7 @@ pub mod pred {
             fn filter(&self, entry: &Entry) -> bool {
                 match entry.get_internal_links() {
                     Err(e)    => (self.errfn)(&e),
-                    Ok(links) => match self.op {
-                        LinkCountOp::LT => links.count() < self.n,
-                        LinkCountOp::EQ => links.count() == self.n,
-                        LinkCountOp::GT => links.count() > self.n,
-                    },
+                    Ok(links) => links.count().cmp(&self.n) == self.op,
                 }
             }
         }

--- a/libimagentrylink/src/internal.rs
+++ b/libimagentrylink/src/internal.rs
@@ -391,13 +391,12 @@ pub mod pred {
         //! for links
 
         use std::error::Error;
-        use std::cell::RefCell;
 
         use filters::filter::Filter;
 
         use libimagstore::store::Entry;
+        use libimagerror::trace::trace_error;
 
-        use super::super::Link;
         use super::super::InternalLinker;
 
         pub enum LinkCountOp {
@@ -440,6 +439,25 @@ pub mod pred {
                 }
             }
         }
+
+        /// Helper function to be passed to ``FilterLinkCount::new()` and denying all entries where
+        /// the link count cannot be found
+        ///
+        /// Additionally, this function invokes `libimagerror::trace::trace_error()` on the error
+        pub fn on_err_no(e: &Error) -> bool {
+            trace_error(e);
+            false
+        }
+
+        /// Helper function to be passed to ``FilterLinkCount::new()` and allowing all entries where
+        /// the link count cannot be found
+        ///
+        /// Additionally, this function invokes `libimagerror::trace::trace_error()` on the error
+        pub fn on_err_yes(e: &Error) -> bool {
+            trace_error(e);
+            true
+        }
+
     }
 
 }

--- a/libimagentrylink/src/internal.rs
+++ b/libimagentrylink/src/internal.rs
@@ -385,6 +385,65 @@ pub mod iter {
 
 }
 
+pub mod pred {
+    pub mod entry {
+        //! Predicate types to be used on iterators over `libimagstore::store::Entry` to filter
+        //! for links
+
+        use std::error::Error;
+        use std::cell::RefCell;
+
+        use filters::filter::Filter;
+
+        use libimagstore::store::Entry;
+
+        use super::super::Link;
+        use super::super::InternalLinker;
+
+        pub enum LinkCountOp {
+            LT,
+            EQ,
+            GT,
+        }
+
+        pub struct FilterLinkCount {
+            op: LinkCountOp,
+            n: usize,
+            errfn: Box<Fn(&Error) -> bool>,
+        }
+
+        impl FilterLinkCount {
+
+            /// Construct a new FilterLinkCount object using the `LinkCountOp` as comperator and `n`
+            /// as righthandside of the comparison.
+            ///
+            /// If the retrieval of the internal links for the `Entry` failed, use the `errfn`
+            /// function to decide whether the entry should be filtered out.
+            pub fn new(op: LinkCountOp, n: usize, errfn: Box<Fn(&Error) -> bool>) -> FilterLinkCount {
+                FilterLinkCount {
+                    op: op,
+                    n: n,
+                    errfn: errfn
+                }
+            }
+        }
+
+        impl Filter<Entry> for FilterLinkCount {
+            fn filter(&self, entry: &Entry) -> bool {
+                match entry.get_internal_links() {
+                    Err(e)    => (self.errfn)(&e),
+                    Ok(links) => match self.op {
+                        LinkCountOp::LT => links.count() < self.n,
+                        LinkCountOp::EQ => links.count() == self.n,
+                        LinkCountOp::GT => links.count() > self.n,
+                    },
+                }
+            }
+        }
+    }
+
+}
+
 impl InternalLinker for Entry {
 
     fn get_internal_links(&self) -> Result<LinkIter> {

--- a/libimagentrylink/src/lib.rs
+++ b/libimagentrylink/src/lib.rs
@@ -38,6 +38,7 @@ extern crate semver;
 extern crate url;
 extern crate crypto;
 #[macro_use] extern crate is_match;
+extern crate filters;
 
 #[cfg(test)]
 extern crate env_logger;


### PR DESCRIPTION
This PR adds some types for filtering with operations on the links of an entry as filter predicate.

What I want to implement:
- [ ] Filter on entries where the predicate function gets the links of an entry
- [ ] Filter on Link objects
