### PR TITLE
Bake in shell-compl generation

### DIFF
--- a/imag-bookmark/Cargo.toml
+++ b/imag-bookmark/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 version = "2.0.1"
 

--- a/imag-counter/Cargo.toml
+++ b/imag-counter/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 version = "2.0.1"
 

--- a/imag-link/Cargo.toml
+++ b/imag-link/Cargo.toml
@@ -15,7 +15,7 @@ homepage      = "http://imag-pim.org"
 
 [dependencies]
 semver = "0.5.1"
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 version = "2.0.1"
 toml = "0.2.*"

--- a/imag-notes/Cargo.toml
+++ b/imag-notes/Cargo.toml
@@ -15,7 +15,7 @@ homepage      = "http://imag-pim.org"
 
 [dependencies]
 semver = "0.2.1"
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 version = "2.0.1"
 itertools = "0.5"

--- a/imag-ref/Cargo.toml
+++ b/imag-ref/Cargo.toml
@@ -15,7 +15,7 @@ homepage      = "http://imag-pim.org"
 
 [dependencies]
 semver = "0.5.1"
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 version = "2.0.1"
 

--- a/imag-todo/Cargo.toml
+++ b/imag-todo/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 glob = "0.2.11"
 log = "0.3.6"
 semver = "0.5.1"

--- a/libimagentryfilter/Cargo.toml
+++ b/libimagentryfilter/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 filters = "0.1.*"
 itertools = "0.5"
 log = "0.3"

--- a/libimaginteraction/Cargo.toml
+++ b/libimaginteraction/Cargo.toml
@@ -15,7 +15,7 @@ homepage      = "http://imag-pim.org"
 
 [dependencies]
 ansi_term = "0.9.*"
-clap = "2.*"
+clap = ">=2.17"
 interactor = "0.1"
 lazy_static = "0.2.*"
 log = "0.3"

--- a/libimagrt/Cargo.toml
+++ b/libimagrt/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = ">=2.16.1"
+clap = ">=2.17"
 env_logger = "0.3"
 toml = "0.2.*"
 log = "0.3"

--- a/libimagrt/Cargo.toml
+++ b/libimagrt/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.16.1"
 env_logger = "0.3"
 toml = "0.2.*"
 log = "0.3"

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -85,8 +85,9 @@ impl<'a> Runtime<'a> {
         match matches.value_of(Runtime::arg_generate_compl()) {
             Some(shell) => {
                 debug!("Generating shell completion script, writing to stdout");
-                let shell = shell.parse::<Shell>().unwrap(); // clap has our back here.
-                cli_spec.gen_completions_to("fakename", shell, &mut stdout());
+                let shell   = shell.parse::<Shell>().unwrap(); // clap has our back here.
+                let appname = String::from(cli_spec.get_name());
+                cli_spec.gen_completions_to(appname, shell, &mut stdout());
             },
             _ => debug!("Not generating shell completion script"),
         }

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -55,7 +55,7 @@ impl<'a> Runtime<'a> {
      * The cli_spec object should be initially build with the ::get_default_cli_builder() function.
      *
      */
-    pub fn new(cli_spec: App<'a, 'a>) -> Result<Runtime<'a>, RuntimeError> {
+    pub fn new(mut cli_spec: App<'a, 'a>) -> Result<Runtime<'a>, RuntimeError> {
         use std::env;
         use std::io::stdout;
 
@@ -74,7 +74,7 @@ impl<'a> Runtime<'a> {
 
         use configuration::error::ConfigErrorKind;
 
-        let matches = cli_spec.get_matches();
+        let matches = cli_spec.clone().get_matches();
 
         let is_debugging = matches.is_present("debugging");
         let is_verbose   = matches.is_present("verbosity");

--- a/libimagtimeui/Cargo.toml
+++ b/libimagtimeui/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 lazy_static = "0.2"
 log = "0.3"
 chrono = "0.2"


### PR DESCRIPTION
Therefor we need to have at least clap 2.16.1.

We bake this into libimagrt::runtime::Runtime, so all binary crates
should automatically have it.

---

Closes #495

Or does it? We then have shell compl for `imag-foo` but not yet for `imag` itself. At least a step into the right direction, IMHO.
