### PR TITLE
Add shell completion

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -17,8 +17,10 @@ build = "build.rs"
 
 [build-dependencies]
 clap = ">=2.16.1"
-libimagrt = { path = "../libimagrt" }
 version = "2.0"
+libimagrt = { path = "../libimagrt" }
+libimagentrytag = { path = "../libimagentrytag" }
+libimagutil = { path = "../libimagutil" }
 
 [profile.dev]
 codegen-units = 2

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -13,6 +13,13 @@ documentation = "https://matthiasbeyer.github.io/imag/imag_documentation/index.h
 repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
+build = "build.rs"
+
+[build-dependencies]
+clap = ">=2.16.1"
+libimagrt = { path = "../libimagrt" }
+version = "2.0"
+
 [profile.dev]
 codegen-units = 2
 

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -17,6 +17,15 @@ macro_rules! gen_types_buildui {
         )
 }
 
+macro_rules! build_subcommand {
+    ($name:expr, $module:ident) => (
+        $module::build_ui(Runtime::get_default_cli_builder(
+                $name,
+                &version!()[..],
+                $name))
+    )
+}
+
 gen_types_buildui!(
     ("../imag-bookmark/src/ui.rs",  imagbookmark),
     ("../imag-counter/src/ui.rs",   imagcounter),
@@ -28,66 +37,27 @@ gen_types_buildui!(
     ("../imag-tag/src/ui.rs",       imagtag),
     ("../imag-todo/src/ui.rs",      imagtodo),
     ("../imag-view/src/ui.rs",      imagview)
-    );
+);
 
 fn main() {
     let mut app = Runtime::get_default_cli_builder(
         "imag",
         &version!()[..],
         "imag")
-        .subcommand(
-            imagbookmark::build_ui(Runtime::get_default_cli_builder(
-                    "bookmark",
-                    &version!()[..],
-                    "bookmark")))
-        .subcommand(
-            imagcounter::build_ui(Runtime::get_default_cli_builder(
-                    "counter",
-                    &version!()[..],
-                    "counter")))
-        .subcommand(
-            imagdiary::build_ui(Runtime::get_default_cli_builder(
-                    "diary",
-                    &version!()[..],
-                    "diary")))
-        .subcommand(
-            imaglink::build_ui(Runtime::get_default_cli_builder(
-                    "link",
-                    &version!()[..],
-                    "link")))
-        .subcommand(
-            imagnotes::build_ui(Runtime::get_default_cli_builder(
-                    "notes",
-                    &version!()[..],
-                    "notes")))
-        .subcommand(
-            imagref::build_ui(Runtime::get_default_cli_builder(
-                    "ref",
-                    &version!()[..],
-                    "ref")))
-        .subcommand(
-            imagstore::build_ui(Runtime::get_default_cli_builder(
-                    "store",
-                    &version!()[..],
-                    "store")))
-        .subcommand(
-            imagtag::build_ui(Runtime::get_default_cli_builder(
-                    "tag",
-                    &version!()[..],
-                    "tag")))
-        .subcommand(
-            imagtodo::build_ui(Runtime::get_default_cli_builder(
-                    "todo",
-                    &version!()[..],
-                    "todo")))
-        .subcommand(
-            imagview::build_ui(Runtime::get_default_cli_builder(
-                    "view",
-                    &version!()[..],
-                    "view")))
-        ;
+        .subcommand(build_subcommand!("bookmark",   imagbookmark))
+        .subcommand(build_subcommand!("counter",    imagcounter))
+        .subcommand(build_subcommand!("diary",      imagdiary))
+        .subcommand(build_subcommand!("link",       imaglink))
+        .subcommand(build_subcommand!("notes",      imagnotes))
+        .subcommand(build_subcommand!("ref",        imagref))
+        .subcommand(build_subcommand!("store",      imagstore))
+        .subcommand(build_subcommand!("tag",        imagtag))
+        .subcommand(build_subcommand!("todo",       imagtodo))
+        .subcommand(build_subcommand!("view",       imagview));
+
     app.gen_completions("imag", Shell::Bash, env!("OUT_DIR"));
     app.gen_completions("imag", Shell::Fish, env!("OUT_DIR"));
     app.gen_completions("imag", Shell::Zsh, env!("OUT_DIR"));
 
 }
+

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -36,6 +36,10 @@ macro_rules! gen_mods_buildui {
 ///     &version!()[..],
 ///     "counter"))
 /// ```
+/// As for the `&version!()[..]` part, it does not matter
+/// which version the subcommand is getting here, as the
+/// output of this script is a completion script, which
+/// does not contain information about the version at all.
 macro_rules! build_subcommand {
     ($name:expr, $module:ident) => (
         $module::build_ui(Runtime::get_default_cli_builder(

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,47 +1,91 @@
 extern crate clap;
 extern crate libimagrt;
+extern crate libimagentrytag;
+extern crate libimagutil;
 #[macro_use] extern crate version;
 
 use clap::Shell;
 use libimagrt::runtime::Runtime;
 
-include!("../imag-store/src/ui.rs");
-
 macro_rules! gen_types_buildui {
     ($(($p:expr, $n:ident)$(,)*)*) => (
-        trait _buildui_fn_type_trait {
-            fn build_ui<'a>(app : App<'a, 'a>) -> App<'a, 'a>;
-        }
         $(
-            struct $n;
-            impl $n {
-                pub fn new() -> Self {
-                    {}
-                }
-            }
-            impl _buildui_fn_type_trait for $n {
+            mod $n {
                 include!($p);
             }
          )*
         )
 }
 
-gen_types_buildui!(("../imag-store/src/ui.rs", imagstore), ("../imag-todo/src/ui.rs", imagtodo));
+gen_types_buildui!(
+    ("../imag-bookmark/src/ui.rs",  imagbookmark),
+    ("../imag-counter/src/ui.rs",   imagcounter),
+    ("../imag-diary/src/ui.rs",     imagdiary),
+    ("../imag-link/src/ui.rs",      imaglink),
+    ("../imag-notes/src/ui.rs",     imagnotes),
+    ("../imag-ref/src/ui.rs",       imagref),
+    ("../imag-store/src/ui.rs",     imagstore),
+    ("../imag-tag/src/ui.rs",       imagtag),
+    ("../imag-todo/src/ui.rs",      imagtodo),
+    ("../imag-view/src/ui.rs",      imagview)
+    );
 
 fn main() {
     let mut app = Runtime::get_default_cli_builder(
         "imag",
         &version!()[..],
-        "imag foo bar");
-    let v = vec![("store", imagstore::new()), ("todo", imagtodo::new())];
-    for (name, obj) in v {
-        app
-            .subcommand(
-                obj::build_ui(Runtime::get_default_cli_builder(
-                        name,
-                        &version!()[..],
-                        name)));
-    }
+        "imag")
+        .subcommand(
+            imagbookmark::build_ui(Runtime::get_default_cli_builder(
+                    "bookmark",
+                    &version!()[..],
+                    "bookmark")))
+        .subcommand(
+            imagcounter::build_ui(Runtime::get_default_cli_builder(
+                    "counter",
+                    &version!()[..],
+                    "counter")))
+        .subcommand(
+            imagdiary::build_ui(Runtime::get_default_cli_builder(
+                    "diary",
+                    &version!()[..],
+                    "diary")))
+        .subcommand(
+            imaglink::build_ui(Runtime::get_default_cli_builder(
+                    "link",
+                    &version!()[..],
+                    "link")))
+        .subcommand(
+            imagnotes::build_ui(Runtime::get_default_cli_builder(
+                    "notes",
+                    &version!()[..],
+                    "notes")))
+        .subcommand(
+            imagref::build_ui(Runtime::get_default_cli_builder(
+                    "ref",
+                    &version!()[..],
+                    "ref")))
+        .subcommand(
+            imagstore::build_ui(Runtime::get_default_cli_builder(
+                    "store",
+                    &version!()[..],
+                    "store")))
+        .subcommand(
+            imagtag::build_ui(Runtime::get_default_cli_builder(
+                    "tag",
+                    &version!()[..],
+                    "tag")))
+        .subcommand(
+            imagtodo::build_ui(Runtime::get_default_cli_builder(
+                    "todo",
+                    &version!()[..],
+                    "todo")))
+        .subcommand(
+            imagview::build_ui(Runtime::get_default_cli_builder(
+                    "view",
+                    &version!()[..],
+                    "view")))
+        ;
     app.gen_completions("imag", Shell::Bash, env!("OUT_DIR"));
     app.gen_completions("imag", Shell::Fish, env!("OUT_DIR"));
     app.gen_completions("imag", Shell::Zsh, env!("OUT_DIR"));

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,0 +1,49 @@
+extern crate clap;
+extern crate libimagrt;
+#[macro_use] extern crate version;
+
+use clap::Shell;
+use libimagrt::runtime::Runtime;
+
+include!("../imag-store/src/ui.rs");
+
+macro_rules! gen_types_buildui {
+    ($(($p:expr, $n:ident)$(,)*)*) => (
+        trait _buildui_fn_type_trait {
+            fn build_ui<'a>(app : App<'a, 'a>) -> App<'a, 'a>;
+        }
+        $(
+            struct $n;
+            impl $n {
+                pub fn new() -> Self {
+                    {}
+                }
+            }
+            impl _buildui_fn_type_trait for $n {
+                include!($p);
+            }
+         )*
+        )
+}
+
+gen_types_buildui!(("../imag-store/src/ui.rs", imagstore), ("../imag-todo/src/ui.rs", imagtodo));
+
+fn main() {
+    let mut app = Runtime::get_default_cli_builder(
+        "imag",
+        &version!()[..],
+        "imag foo bar");
+    let v = vec![("store", imagstore::new()), ("todo", imagtodo::new())];
+    for (name, obj) in v {
+        app
+            .subcommand(
+                obj::build_ui(Runtime::get_default_cli_builder(
+                        name,
+                        &version!()[..],
+                        name)));
+    }
+    app.gen_completions("imag", Shell::Bash, env!("OUT_DIR"));
+    app.gen_completions("imag", Shell::Fish, env!("OUT_DIR"));
+    app.gen_completions("imag", Shell::Zsh, env!("OUT_DIR"));
+
+}


### PR DESCRIPTION
I present a solution for the "shell-completion problem", though the "how" may be a bit... discussable.
It somehow works, which is kind of surprising, as it literally is my first macro in rust.
There definitely is space for improval, as there is still duplicate code (9 times `.subcommand(...)`).
Testing is definitely welcome, as this work is in the "10 minutes ago I ran it and it actually worked (on my machine)" kind of state.
Also this kind of solution will require maintenance when adding new binaries to imag. Furthermore, the completion is generated at compiletime, which might or might not be considered a downside.