### PR TITLE
Don't re-open temporary file.

### DIFF
--- a/libimagutil/src/edit.rs
+++ b/libimagutil/src/edit.rs
@@ -27,9 +27,8 @@ use std::io::Error as IOError;
 use tempfile::NamedTempFile;
 
 pub fn edit_in_tmpfile_with_command(mut cmd: Command, s: &mut String) -> Result<bool, IOError> {
-    let file      = try!(NamedTempFile::new());
+    let mut file  = &try!(NamedTempFile::new());
     let file_path = file.path();
-    let mut file  = try!(file.reopen());
 
     try!(file.write_all(&s.clone().into_bytes()[..]));
     try!(file.sync_data());


### PR DESCRIPTION
`Write` is implemented on both `&NamedTemporaryFile` and `&File` so you don't actually need a mutable reference. I wish there were a better way to do this but such is life.