### PR TITLE
libimagstore: Eliminate EntryHeader type

### DIFF
--- a/imag-store/Cargo.toml
+++ b/imag-store/Cargo.toml
@@ -34,3 +34,6 @@ path = "../libimagutil"
 [dependencies.libimagerror]
 path = "../libimagerror"
 
+[features]
+early-panic = [ "libimagstore/early-panic" ]
+

--- a/imag-store/src/retrieve.rs
+++ b/imag-store/src/retrieve.rs
@@ -20,7 +20,6 @@
 use std::path::PathBuf;
 
 use clap::ArgMatches;
-use toml::Value;
 
 use libimagstore::store::FileLockEntry;
 use libimagstore::storeid::StoreId;
@@ -70,8 +69,7 @@ pub fn print_entry(rt: &Runtime, scmd: &ArgMatches, e: FileLockEntry) {
                 unimplemented!()
             } else {
                 debug!("Printing header as TOML...");
-                // We have to Value::Table() for Display
-                println!("{}", Value::Table(e.get_header().clone().into()))
+                println!("{}", e.get_header())
             }
         }
 

--- a/libimagentryfilter/src/builtin/header/field_exists.rs
+++ b/libimagentryfilter/src/builtin/header/field_exists.rs
@@ -18,6 +18,7 @@
 //
 
 use libimagstore::store::Entry;
+use libimagstore::toml_ext::TomlValueExt;
 
 use builtin::header::field_path::FieldPath;
 use filters::filter::Filter;

--- a/libimagentryfilter/src/builtin/header/field_isempty.rs
+++ b/libimagentryfilter/src/builtin/header/field_isempty.rs
@@ -18,6 +18,7 @@
 //
 
 use libimagstore::store::Entry;
+use libimagstore::toml_ext::TomlValueExt;
 
 use builtin::header::field_path::FieldPath;
 use filters::filter::Filter;

--- a/libimagentryfilter/src/builtin/header/field_predicate.rs
+++ b/libimagentryfilter/src/builtin/header/field_predicate.rs
@@ -18,6 +18,7 @@
 //
 
 use libimagstore::store::Entry;
+use libimagstore::toml_ext::TomlValueExt;
 
 use builtin::header::field_path::FieldPath;
 use filters::filter::Filter;

--- a/libimagentryfilter/src/builtin/header/version/eq.rs
+++ b/libimagentryfilter/src/builtin/header/version/eq.rs
@@ -21,6 +21,7 @@ use semver::Version;
 use toml::Value;
 
 use libimagstore::store::Entry;
+use libimagstore::toml_ext::TomlValueExt;
 
 use filters::filter::Filter;
 

--- a/libimagentryfilter/src/builtin/header/version/gt.rs
+++ b/libimagentryfilter/src/builtin/header/version/gt.rs
@@ -21,6 +21,7 @@ use semver::Version;
 use toml::Value;
 
 use libimagstore::store::Entry;
+use libimagstore::toml_ext::TomlValueExt;
 
 use filters::filter::Filter;
 

--- a/libimagentryfilter/src/builtin/header/version/lt.rs
+++ b/libimagentryfilter/src/builtin/header/version/lt.rs
@@ -21,6 +21,7 @@ use semver::Version;
 use toml::Value;
 
 use libimagstore::store::Entry;
+use libimagstore::toml_ext::TomlValueExt;
 
 use filters::filter::Filter;
 

--- a/libimagentrylink/src/external.rs
+++ b/libimagentrylink/src/external.rs
@@ -38,6 +38,7 @@ use libimagstore::store::FileLockEntry;
 use libimagstore::store::Store;
 use libimagstore::storeid::StoreId;
 use libimagstore::storeid::IntoStoreId;
+use libimagstore::toml_ext::TomlValueExt;
 use libimagutil::debug_result::*;
 
 use error::LinkError as LE;

--- a/libimagentrylink/src/internal.rs
+++ b/libimagentrylink/src/internal.rs
@@ -19,7 +19,6 @@
 
 use libimagstore::storeid::StoreId;
 use libimagstore::store::Entry;
-use libimagstore::store::EntryHeader;
 use libimagstore::store::Result as StoreResult;
 use libimagstore::toml_ext::TomlValueExt;
 use libimagerror::into::IntoError;
@@ -338,7 +337,7 @@ impl InternalLinker for Entry {
 
 }
 
-fn rewrite_links<I: Iterator<Item = Link>>(header: &mut EntryHeader, links: I) -> Result<()> {
+fn rewrite_links<I: Iterator<Item = Link>>(header: &mut Value, links: I) -> Result<()> {
     let links = try!(links.into_values()
                      .fold(Ok(vec![]), |acc, elem| {
                         acc.and_then(move |mut v| {

--- a/libimagentrylink/src/internal.rs
+++ b/libimagentrylink/src/internal.rs
@@ -21,6 +21,7 @@ use libimagstore::storeid::StoreId;
 use libimagstore::store::Entry;
 use libimagstore::store::EntryHeader;
 use libimagstore::store::Result as StoreResult;
+use libimagstore::toml_ext::TomlValueExt;
 use libimagerror::into::IntoError;
 
 use error::LinkErrorKind as LEK;

--- a/libimagentrytag/src/tagable.rs
+++ b/libimagentrytag/src/tagable.rs
@@ -19,8 +19,9 @@
 
 use itertools::Itertools;
 
-use libimagstore::store::{Entry, EntryHeader};
+use libimagstore::store::Entry;
 use libimagerror::into::IntoError;
+use libimagstore::toml_ext::TomlValueExt;
 
 use error::TagErrorKind;
 use error::MapErrInto;
@@ -43,7 +44,7 @@ pub trait Tagable {
 
 }
 
-impl Tagable for EntryHeader {
+impl Tagable for Value {
 
     fn get_tags(&self) -> Result<Vec<Tag>> {
         let tags = try!(self.read("imag.tags").map_err_into(TagErrorKind::HeaderReadError));

--- a/libimagentryview/src/builtin/plain.rs
+++ b/libimagentryview/src/builtin/plain.rs
@@ -40,7 +40,7 @@ impl Viewer for PlainViewer {
 
     fn view_entry(&self, e: &Entry) -> Result<()> {
         if self.show_header {
-            println!("{}", e.get_header().header());
+            println!("{}", e.get_header());
         }
         println!("{}", e.get_content());
         Ok(())

--- a/libimagentryview/src/builtin/stdout.rs
+++ b/libimagentryview/src/builtin/stdout.rs
@@ -44,7 +44,7 @@ impl Viewer for StdoutViewer {
 
     fn view_entry(&self, e: &Entry) -> Result<()> {
         if self.view_header {
-            println!("{}", encode_str(e.get_header().header()));
+            println!("{}", encode_str(e.get_header()));
         }
 
         if self.view_content {

--- a/libimagnotes/src/note.rs
+++ b/libimagnotes/src/note.rs
@@ -30,6 +30,7 @@ use libimagstore::storeid::StoreId;
 use libimagstore::storeid::StoreIdIterator;
 use libimagstore::store::FileLockEntry;
 use libimagstore::store::Store;
+use libimagstore::toml_ext::TomlValueExt;
 use libimagentrytag::tag::{Tag, TagSlice};
 use libimagentrytag::tagable::Tagable;
 use libimagentrytag::result::Result as TagResult;

--- a/libimagref/src/reference.rs
+++ b/libimagref/src/reference.rs
@@ -33,6 +33,7 @@ use libimagstore::store::FileLockEntry;
 use libimagstore::storeid::StoreId;
 use libimagstore::storeid::IntoStoreId;
 use libimagstore::store::Store;
+use libimagstore::toml_ext::TomlValueExt;
 use libimagerror::into::IntoError;
 
 use toml::Value;

--- a/libimagruby/src/entry.rs
+++ b/libimagruby/src/entry.rs
@@ -21,11 +21,12 @@ use std::collections::BTreeMap;
 use std::error::Error;
 
 use ruru::{Class, Object, AnyObject, Boolean, RString, VM, Hash, NilClass, VerifiedObject};
+use toml::Value;
 
-use libimagstore::store::EntryHeader;
 use libimagstore::store::EntryContent;
 use libimagstore::store::Entry;
 use libimagstore::storeid::StoreId;
+use libimagstore::toml_ext::TomlValueExt;
 
 use ruby_utils::IntoToml;
 use toml_utils::IntoRuby;
@@ -130,7 +131,7 @@ methods!(
         use toml::Value;
 
         let entryheader = match typecheck!(hdr or return NilClass::new()).into_toml() {
-            Value::Table(t) => EntryHeader::from(t),
+            Value::Table(t) => Value::Table(t),
             _ => {
                 let ec = Class::from_existing("RuntimeError");
                 VM::raise(ec, "Something weird happened. Hash seems to be not a Hash");
@@ -175,10 +176,10 @@ methods!(
 
 );
 
-wrappable_struct!(EntryHeader, EntryHeaderWrapper, ENTRY_HEADER_WRAPPER);
+wrappable_struct!(Value, EntryHeaderWrapper, ENTRY_HEADER_WRAPPER);
 class!(REntryHeader);
-impl_wrap!(EntryHeader => ENTRY_HEADER_WRAPPER);
-impl_unwrap!(REntryHeader => EntryHeader => ENTRY_HEADER_WRAPPER);
+impl_wrap!(Value => ENTRY_HEADER_WRAPPER);
+impl_unwrap!(REntryHeader => Value => ENTRY_HEADER_WRAPPER);
 impl_verified_object!(REntryHeader);
 
 methods!(
@@ -186,7 +187,7 @@ methods!(
     itself,
 
     fn r_entry_header_new() -> AnyObject {
-        EntryHeader::new().wrap()
+        Entry::default_header().wrap()
     }
 
     fn r_entry_header_insert(spec: RString, obj: AnyObject) -> Boolean {

--- a/libimagstore/Cargo.toml
+++ b/libimagstore/Cargo.toml
@@ -40,7 +40,27 @@ default = []
 verify  = []
 
 # Enable panic!()s if critical errors occur.
-# Can be used to debug the store more intensly via the imag-store commandline
-# application
+#
+# # Howto
+#
+# To enable this, put
+#
+# ```toml
+# [features]
+# early-panic = [ "libimagstore/early-panic" ]
+# ```
+#
+# In the crate depending on this library and compile your crate with
+# `cargo build --features early-panic`. This way, the `libimagstore`
+# implementation fails via `panic!()` instead of propagating errors which have
+# to be printed somewhere to be visible.
+#
+# # WARNING
+#
+# The behaviour of the store implementation might be broken with this, resulting
+# in partially written store entries and/or worse, so this is
+#
+#    _NOT INTENDED FOR PRODUCTION USE_!
+#
 early-panic=[]
 

--- a/libimagstore/Cargo.toml
+++ b/libimagstore/Cargo.toml
@@ -39,3 +39,8 @@ env_logger = "0.3"
 default = []
 verify  = []
 
+# Enable panic!()s if critical errors occur.
+# Can be used to debug the store more intensly via the imag-store commandline
+# application
+early-panic=[]
+

--- a/libimagstore/src/lib.rs
+++ b/libimagstore/src/lib.rs
@@ -52,5 +52,5 @@ pub mod hook;
 pub mod store;
 mod configuration;
 mod file_abstraction;
-mod toml_ext;
+pub mod toml_ext;
 

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -23,7 +23,6 @@ use std::path::PathBuf;
 use std::result::Result as RResult;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::collections::BTreeMap;
 use std::io::Read;
 use std::convert::From;
 use std::convert::Into;
@@ -34,13 +33,12 @@ use std::fmt::Formatter;
 use std::fmt::Debug;
 use std::fmt::Error as FMTError;
 
-use toml::{Table, Value};
+use toml::Value;
 use regex::Regex;
 use glob::glob;
 use walkdir::WalkDir;
 use walkdir::Iter as WalkDirIter;
 
-use error::{ParserErrorKind, ParserError};
 use error::{StoreError as SE, StoreErrorKind as SEK};
 use error::MapErrInto;
 use storeid::{IntoStoreId, StoreId, StoreIdIterator};
@@ -960,176 +958,6 @@ impl<'a> Drop for FileLockEntry<'a> {
 /// `EntryContent` type
 pub type EntryContent = String;
 
-/// `EntryHeader`
-///
-/// This is basically a wrapper around `toml::Table` which provides convenience to the user of the
-/// library.
-#[derive(Debug, Clone, PartialEq)]
-pub struct EntryHeader(Value);
-
-pub type EntryResult<V> = RResult<V, ParserError>;
-
-/**
- * Wrapper type around file header (TOML) object
- */
-impl EntryHeader {
-
-    pub fn new() -> EntryHeader {
-        EntryHeader(build_default_header())
-    }
-
-    pub fn header(&self) -> &Value {
-        &self.0
-    }
-
-    fn from_table(t: Table) -> EntryHeader {
-        EntryHeader(Value::Table(t))
-    }
-
-    pub fn parse(s: &str) -> EntryResult<EntryHeader> {
-        use toml::Parser;
-
-        let mut parser = Parser::new(s);
-        parser.parse()
-            .ok_or(ParserErrorKind::TOMLParserErrors.into())
-            .and_then(verify_header_consistency)
-            .map(EntryHeader::from_table)
-    }
-
-    pub fn verify(&self) -> Result<()> {
-        match self.0 {
-            Value::Table(ref t) => verify_header(&t),
-            _ => Err(SE::new(SEK::HeaderTypeFailure, None)),
-        }
-    }
-
-    #[inline]
-    pub fn insert_with_sep(&mut self, spec: &str, sep: char, v: Value) -> Result<bool> {
-        self.0.insert_with_sep(spec, sep, v)
-    }
-
-    #[inline]
-    pub fn set_with_sep(&mut self, spec: &str, sep: char, v: Value) -> Result<Option<Value>> {
-        self.0.set_with_sep(spec, sep, v)
-    }
-
-    #[inline]
-    pub fn read_with_sep(&self, spec: &str, splitchr: char) -> Result<Option<Value>> {
-        self.0.read_with_sep(spec, splitchr)
-    }
-
-    #[inline]
-    pub fn delete_with_sep(&mut self, spec: &str, splitchr: char) -> Result<Option<Value>> {
-        self.0.delete_with_sep(spec, splitchr)
-    }
-
-    #[inline]
-    pub fn insert(&mut self, spec: &str, v: Value) -> Result<bool> {
-        self.0.insert(spec, v)
-    }
-
-    #[inline]
-    pub fn set(&mut self, spec: &str, v: Value) -> Result<Option<Value>> {
-        self.0.set(spec, v)
-    }
-
-    #[inline]
-    pub fn read(&self, spec: &str) -> Result<Option<Value>> {
-        self.0.read(spec)
-    }
-
-    #[inline]
-    pub fn delete(&mut self, spec: &str) -> Result<Option<Value>> {
-        self.0.delete(spec)
-    }
-
-}
-
-impl Into<Table> for EntryHeader {
-
-    fn into(self) -> Table {
-        match self.0 {
-            Value::Table(t) => t,
-            _ => panic!("EntryHeader is not a table!"),
-        }
-    }
-
-}
-
-impl From<Table> for EntryHeader {
-
-    fn from(t: Table) -> EntryHeader {
-        EntryHeader(Value::Table(t))
-    }
-
-}
-
-fn build_default_header() -> Value { // BTreeMap<String, Value>
-    let mut m = BTreeMap::new();
-
-    m.insert(String::from("imag"), {
-        let mut imag_map = BTreeMap::<String, Value>::new();
-
-        imag_map.insert(String::from("version"), Value::String(String::from(version!())));
-        imag_map.insert(String::from("links"), Value::Array(vec![]));
-
-        Value::Table(imag_map)
-    });
-
-    Value::Table(m)
-}
-fn verify_header(t: &Table) -> Result<()> {
-    if !has_main_section(t) {
-        Err(SE::from(ParserErrorKind::MissingMainSection.into_error()))
-    } else if !has_imag_version_in_main_section(t) {
-        Err(SE::from(ParserErrorKind::MissingVersionInfo.into_error()))
-    } else if !has_only_tables(t) {
-        debug!("Could not verify that it only has tables in its base table");
-        Err(SE::from(ParserErrorKind::NonTableInBaseTable.into_error()))
-    } else {
-        Ok(())
-    }
-}
-
-fn verify_header_consistency(t: Table) -> EntryResult<Table> {
-    verify_header(&t)
-        .map_err(Box::new)
-        .map_err(|e| ParserErrorKind::HeaderInconsistency.into_error_with_cause(e))
-        .map(|_| t)
-}
-
-fn has_only_tables(t: &Table) -> bool {
-    debug!("Verifying that table has only tables");
-    t.iter().all(|(_, x)| if let Value::Table(_) = *x { true } else { false })
-}
-
-fn has_main_section(t: &Table) -> bool {
-    t.contains_key("imag") &&
-        match t.get("imag") {
-            Some(&Value::Table(_)) => true,
-            Some(_)                => false,
-            None                   => false,
-        }
-}
-
-fn has_imag_version_in_main_section(t: &Table) -> bool {
-    use semver::Version;
-
-    match *t.get("imag").unwrap() {
-        Value::Table(ref sec) => {
-            sec.get("version")
-                .and_then(|v| {
-                    match *v {
-                        Value::String(ref s) => Some(Version::parse(&s[..]).is_ok()),
-                        _                    => Some(false),
-                    }
-                })
-            .unwrap_or(false)
-        }
-        _ => false,
-    }
-}
-
 /**
  * An Entry of the store
  *
@@ -1138,7 +966,7 @@ fn has_imag_version_in_main_section(t: &Table) -> bool {
 #[derive(Debug, Clone)]
 pub struct Entry {
     location: StoreId,
-    header: EntryHeader,
+    header: Value,
     content: EntryContent,
 }
 
@@ -1147,9 +975,13 @@ impl Entry {
     pub fn new(loc: StoreId) -> Entry {
         Entry {
             location: loc,
-            header: EntryHeader::new(),
+            header: Entry::default_header(),
             content: EntryContent::new()
         }
+    }
+
+    pub fn default_header() -> Value { // BTreeMap<String, Value>
+        Value::default_header()
     }
 
     pub fn from_reader<S: IntoStoreId>(loc: S, file: &mut Read) -> Result<Entry> {
@@ -1187,14 +1019,14 @@ impl Entry {
         debug!("Header and content found. Yay! Building Entry object now");
         Ok(Entry {
             location: try!(loc.into_storeid()),
-            header: try!(EntryHeader::parse(header.as_str())),
+            header: try!(Value::parse(header.as_str())),
             content: String::from(content),
         })
     }
 
     pub fn to_str(&self) -> String {
         format!("---\n{header}---\n{content}",
-                header  = ::toml::encode_str(&self.header.0),
+                header  = ::toml::encode_str(&self.header),
                 content = self.content)
     }
 
@@ -1202,11 +1034,11 @@ impl Entry {
         &self.location
     }
 
-    pub fn get_header(&self) -> &EntryHeader {
+    pub fn get_header(&self) -> &Value {
         &self.header
     }
 
-    pub fn get_header_mut(&mut self) -> &mut EntryHeader {
+    pub fn get_header_mut(&mut self) -> &mut Value {
         &mut self.header
     }
 
@@ -1378,7 +1210,7 @@ mod test {
 
     #[test]
     fn test_verification_good() {
-        use super::verify_header_consistency;
+        use toml_ext::verify_header_consistency;
 
         let mut header = BTreeMap::new();
         let sub = {
@@ -1395,7 +1227,7 @@ mod test {
 
     #[test]
     fn test_verification_invalid_versionstring() {
-        use super::verify_header_consistency;
+        use toml_ext::verify_header_consistency;
 
         let mut header = BTreeMap::new();
         let sub = {
@@ -1413,7 +1245,7 @@ mod test {
 
     #[test]
     fn test_verification_current_version() {
-        use super::verify_header_consistency;
+        use toml_ext::verify_header_consistency;
 
         let mut header = BTreeMap::new();
         let sub = {

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1146,7 +1146,7 @@ mod test {
 
     #[test]
     fn test_imag_section() {
-        use super::has_main_section;
+        use toml_ext::has_main_section;
 
         let mut map = BTreeMap::new();
         map.insert("imag".into(), Value::Table(BTreeMap::new()));
@@ -1156,7 +1156,7 @@ mod test {
 
     #[test]
     fn test_imag_invalid_section_type() {
-        use super::has_main_section;
+        use toml_ext::has_main_section;
 
         let mut map = BTreeMap::new();
         map.insert("imag".into(), Value::Boolean(false));
@@ -1166,7 +1166,7 @@ mod test {
 
     #[test]
     fn test_imag_abscent_main_section() {
-        use super::has_main_section;
+        use toml_ext::has_main_section;
 
         let mut map = BTreeMap::new();
         map.insert("not_imag".into(), Value::Boolean(false));

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -942,7 +942,15 @@ impl<'a> DerefMut for FileLockEntry<'a> {
 impl<'a> Drop for FileLockEntry<'a> {
     /// This will silently ignore errors, use `Store::update` if you want to catch the errors
     fn drop(&mut self) {
-        let _ = self.store._update(self, true);
+        use libimagerror::trace::trace_error_dbg;
+
+        match self.store._update(self, true) {
+            Err(e) => {
+                trace_error_dbg(&e);
+                if_cfg_panic!("ERROR WHILE DROPPING: {:?}", e);
+            },
+            Ok(_) => { },
+        }
     }
 }
 

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1176,7 +1176,7 @@ mod test {
 
     #[test]
     fn test_main_section_without_version() {
-        use super::has_imag_version_in_main_section;
+        use toml_ext::has_imag_version_in_main_section;
 
         let mut map = BTreeMap::new();
         map.insert("imag".into(), Value::Table(BTreeMap::new()));
@@ -1186,7 +1186,7 @@ mod test {
 
     #[test]
     fn test_main_section_with_version() {
-        use super::has_imag_version_in_main_section;
+        use toml_ext::has_imag_version_in_main_section;
 
         let mut map = BTreeMap::new();
         let mut sub = BTreeMap::new();
@@ -1198,7 +1198,7 @@ mod test {
 
     #[test]
     fn test_main_section_with_version_in_wrong_type() {
-        use super::has_imag_version_in_main_section;
+        use toml_ext::has_imag_version_in_main_section;
 
         let mut map = BTreeMap::new();
         let mut sub = BTreeMap::new();

--- a/libimagstore/src/toml_ext.rs
+++ b/libimagstore/src/toml_ext.rs
@@ -426,7 +426,7 @@ fn verify_header(t: &Table) -> Result<()> {
 
 fn has_only_tables(t: &Table) -> bool {
     debug!("Verifying that table has only tables");
-    t.iter().all(|(_, x)| if let Value::Table(_) = *x { true } else { false })
+    t.iter().all(|(_, x)| is_match!(*x, Value::Table(_)))
 }
 
 fn has_main_section(t: &Table) -> bool {

--- a/libimagstore/src/toml_ext.rs
+++ b/libimagstore/src/toml_ext.rs
@@ -429,13 +429,8 @@ fn has_only_tables(t: &Table) -> bool {
     t.iter().all(|(_, x)| is_match!(*x, Value::Table(_)))
 }
 
-fn has_main_section(t: &Table) -> bool {
-    t.contains_key("imag") &&
-        match t.get("imag") {
-            Some(&Value::Table(_)) => true,
-            Some(_)                => false,
-            None                   => false,
-        }
+pub fn has_main_section(t: &Table) -> bool {
+    t.contains_key("imag") && is_match!(t.get("imag"), Some(&Value::Table(_)))
 }
 
 fn has_imag_version_in_main_section(t: &Table) -> bool {

--- a/libimagstore/src/toml_ext.rs
+++ b/libimagstore/src/toml_ext.rs
@@ -433,7 +433,7 @@ pub fn has_main_section(t: &Table) -> bool {
     t.contains_key("imag") && is_match!(t.get("imag"), Some(&Value::Table(_)))
 }
 
-fn has_imag_version_in_main_section(t: &Table) -> bool {
+pub fn has_imag_version_in_main_section(t: &Table) -> bool {
     use semver::Version;
 
     match *t.get("imag").unwrap() {

--- a/libimagstore/src/util.rs
+++ b/libimagstore/src/util.rs
@@ -17,42 +17,19 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-#![deny(
-    non_camel_case_types,
-    non_snake_case,
-    path_statements,
-    trivial_numeric_casts,
-    unstable_features,
-    unused_allocation,
-    unused_import_braces,
-    unused_imports,
-    unused_mut,
-    unused_qualifications,
-    while_true,
-)]
+#[cfg(feature = "early-panic")]
+#[macro_export]
+macro_rules! if_cfg_panic {
+    ()                       => { panic!() };
+    ($msg:expr)              => { panic!($msg) };
+    ($fmt:expr, $($arg:tt)+) => { panic!($fmt, $($($arg),*)) };
+}
 
-#[macro_use] extern crate log;
-#[macro_use] extern crate version;
-extern crate fs2;
-extern crate glob;
-#[macro_use] extern crate lazy_static;
-extern crate regex;
-extern crate toml;
-#[cfg(test)] extern crate tempdir;
-extern crate semver;
-extern crate crossbeam;
-extern crate walkdir;
-
-#[macro_use] extern crate libimagerror;
-#[macro_use] extern crate libimagutil;
-
-#[macro_use] mod util;
-
-pub mod storeid;
-pub mod error;
-pub mod hook;
-pub mod store;
-mod configuration;
-mod file_abstraction;
-pub mod toml_ext;
+#[cfg(not(feature = "early-panic"))]
+#[macro_export]
+macro_rules! if_cfg_panic {
+    ()                       => { };
+    ($msg:expr)              => { };
+    ($fmt:expr, $($arg:tt)+) => { };
+}
 


### PR DESCRIPTION
Followup for #835 

This eliminates the `EntryHeader` type by moving the functionality to traits implemented on `toml::Value`.

Refactoring is about to be done.