### PR TITLE
Clap version bump

### DIFF
--- a/imag-store/Cargo.toml
+++ b/imag-store/Cargo.toml
@@ -17,7 +17,7 @@ homepage      = "http://imag-pim.org"
 codegen-units = 2
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 version = "2.0.1"
 semver = "0.5"

--- a/imag-view/Cargo.toml
+++ b/imag-view/Cargo.toml
@@ -17,7 +17,7 @@ homepage      = "http://imag-pim.org"
 codegen-units = 2
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 semver = "0.5"
 toml = "0.2.*"

--- a/libimagentrytag/Cargo.toml
+++ b/libimagentrytag/Cargo.toml
@@ -17,7 +17,7 @@ homepage      = "http://imag-pim.org"
 codegen-units = 2
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 regex = "0.1"
 toml = "0.2.*"


### PR DESCRIPTION
Bump `clap` to at least 2.17 in crates where it isn't already.