### PR TITLE
Make logger types public

### DIFF
--- a/libimagrt/src/lib.rs
+++ b/libimagrt/src/lib.rs
@@ -49,9 +49,9 @@ extern crate libimagutil;
 #[macro_use] extern crate libimagerror;
 
 mod configuration;
-mod logger;
 
 pub mod error;
+pub mod logger;
 pub mod runtime;
 pub mod setup;
 

--- a/libimagrt/src/logger.rs
+++ b/libimagrt/src/logger.rs
@@ -27,6 +27,7 @@ use ansi_term::Colour;
 use ansi_term::ANSIString;
 
 pub struct ImagLogger {
+    prefix: String,
     lvl: LogLevel,
     color_enabled: bool,
 }
@@ -35,9 +36,15 @@ impl ImagLogger {
 
     pub fn new(lvl: LogLevel) -> ImagLogger {
         ImagLogger {
+            prefix: "[imag]".to_owned(),
             lvl: lvl,
             color_enabled: true
         }
+    }
+
+    pub fn with_prefix(mut self, pref: String) -> ImagLogger {
+        self.prefix = pref;
+        self
     }
 
     pub fn with_color(mut self, b: bool) -> ImagLogger {
@@ -84,22 +91,22 @@ impl Log for ImagLogger {
                     let ln   = self.color_or_not(Cyan, format!("{}", loc.line()));
                     let args = self.color_or_not(Cyan, format!("{}", record.args()));
 
-                    writeln!(stderr(), "[imag][{: <5}][{}][{: >5}]: {}", lvl, file, ln, args).ok();
+                    writeln!(stderr(), "{}[{: <5}][{}][{: >5}]: {}", self.prefix, lvl, file, ln, args).ok();
                 },
                 LogLevel::Warn | LogLevel::Error => {
                     let lvl  = self.style_or_not(Red.blink(), format!("{}", record.level()));
                     let args = self.color_or_not(Red, format!("{}", record.args()));
 
-                    writeln!(stderr(), "[imag][{: <5}]: {}", lvl, args).ok();
+                    writeln!(stderr(), "{}[{: <5}]: {}", self.prefix, lvl, args).ok();
                 },
                 LogLevel::Info => {
                     let lvl  = self.color_or_not(Yellow, format!("{}", record.level()));
                     let args = self.color_or_not(Yellow, format!("{}", record.args()));
 
-                    writeln!(stderr(), "[imag][{: <5}]: {}", lvl, args).ok();
+                    writeln!(stderr(), "{}[{: <5}]: {}", self.prefix, lvl, args).ok();
                 },
                 _ => {
-                    writeln!(stderr(), "[imag][{: <5}]: {}", record.level(), record.args()).ok();
+                    writeln!(stderr(), "{}[{: <5}]: {}", self.prefix, record.level(), record.args()).ok();
                 },
             }
         }


### PR DESCRIPTION
This commit makes the logging functionality types from libimagrt public,
so the libimagruby implementation can re-use the ImagLogger type.

---

Extracted from #847 - @mario-kr I guess this is okay, isn't it? I'm not sure. We expose the logging utilities of libimagrt - still, Rust binaries should initialize the logger via the `Runtime` type.
This is just done so I can use the `ImagLogger` type in the Ruby library to initialize a logger from Ruby code.