### PR TITLE
Libimagrt/config types pub

### DIFF
--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -34,7 +34,7 @@ generate_error_module!(
     );
 );
 
-use self::error::{ConfigError, ConfigErrorKind};
+pub use self::error::{ConfigError, ConfigErrorKind};
 
 /**
  * Result type of this module. Either `T` or `ConfigError`

--- a/libimagrt/src/lib.rs
+++ b/libimagrt/src/lib.rs
@@ -48,9 +48,8 @@ extern crate libimagstorestdhook;
 extern crate libimagutil;
 #[macro_use] extern crate libimagerror;
 
-mod configuration;
-
 pub mod error;
+pub mod configuration;
 pub mod logger;
 pub mod runtime;
 pub mod setup;


### PR DESCRIPTION
Another PR extracted from #847 

We need these types in the Ruby library as well.

We clearly should refactor a few things before the next release here, ... making these things public is not really nice in my opinion.
