### PR TITLE
Fix: Pass error return expression further down

### DIFF
--- a/libimagruby/src/entry.rs
+++ b/libimagruby/src/entry.rs
@@ -107,7 +107,7 @@ macro_rules! call_on_fle_from_store {
                         $ex
                     },
                 }
-            }
+            } on fail return $ex
         }
     }};
 }


### PR DESCRIPTION
Fixes a macro which didn't pass the error type expression further down...