### PR TITLE
Ruby testing

### DIFF
--- a/libimagruby/Makefile
+++ b/libimagruby/Makefile
@@ -10,11 +10,12 @@ bundle:
 	@$(BUNDLE) install --path vendor/bundle
 
 tarball: bundle
-	@$(ECHO) "[RAKE  ][thermite]"
+	@$(ECHO) "[RAKE  ][thermite]: tarball"
 	@CARGO_TARGET=debug $(BUNDLE) exec rake thermite:tarball
 
 test: tarball
-	@$(ECHO) "[TEST  ] Not yet implemented. :-("
+	@$(ECHO) "[RAKE  ][thermite]: test"
+	@CARGO_TARGET=debug $(BUNDLE) exec rake test
 
 .FORCE:
 

--- a/libimagruby/Rakefile
+++ b/libimagruby/Rakefile
@@ -1,5 +1,14 @@
-require "bundler/gem_tasks"
 require 'thermite/tasks'
 
-Thermite::Tasks.new(cargo_project_path: "..", cargo_workspace_member: "libimagruby")
+Thermite::Tasks.new(cargo_project_path: "..", cargo_workspace_member: "libimagruby", ruby_project_path: ".")
 
+task default: %w(thermite:build)
+
+desc 'Run Rust & Ruby testsuites'
+task test: ['thermite:build', 'thermite:test'] do
+  [
+    "test_methods_present"
+  ].each do |name|
+    ruby File.join(File.dirname(__FILE__), 'tests', "#{name}.rb")
+  end
+end

--- a/libimagruby/Rakefile
+++ b/libimagruby/Rakefile
@@ -6,8 +6,8 @@ task default: %w(thermite:build)
 
 desc 'Run Rust & Ruby testsuites'
 task test: ['thermite:build', 'thermite:test'] do
-  [ "test_methods_present"
-  , "test_store_crud"
+  [ "test_methods_present",
+    "test_store_crud"
   ].each do |name|
     ruby File.join(File.dirname(__FILE__), 'tests', "#{name}.rb")
   end

--- a/libimagruby/Rakefile
+++ b/libimagruby/Rakefile
@@ -6,8 +6,8 @@ task default: %w(thermite:build)
 
 desc 'Run Rust & Ruby testsuites'
 task test: ['thermite:build', 'thermite:test'] do
-  [
-    "test_methods_present"
+  [ "test_methods_present"
+  , "test_store_crud"
   ].each do |name|
     ruby File.join(File.dirname(__FILE__), 'tests', "#{name}.rb")
   end

--- a/libimagruby/ext/Rakefile
+++ b/libimagruby/ext/Rakefile
@@ -1,5 +1,0 @@
-require 'thermite/tasks'
-
-Thermite::Tasks.new(cargo_project_path: "..", cargo_workspace_member: "libimagruby")
-task default: %w(thermite:build)
-

--- a/libimagruby/imag.gemspec
+++ b/libimagruby/imag.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'thermite', "~> 0.11", ">= 0.11.1"
-
-  spec.extensions << 'ext/Rakefile'
+  spec.add_development_dependency 'minitest', "~> 5.9"
 end

--- a/libimagruby/tests/test_methods_present.rb
+++ b/libimagruby/tests/test_methods_present.rb
@@ -9,6 +9,19 @@ class BasicImagInterfaceTest < Minitest::Test
     # nothing
   end
 
+  def test_constants_exist
+    [ :Logger
+    , :StoreId
+    , :StoreHandle
+    , :FileLockEntryHandle
+    , :EntryHeader
+    , :EntryContent
+    , :VERSION
+    ].each do |k|
+      assert Imag.constants.include? k
+    end
+  end
+
   def test_logger_methods_exist
     [:init, :trace, :dbg, :debug, :info, :warn, :error].each do |m|
       assert Imag::Logger.methods.include? m

--- a/libimagruby/tests/test_methods_present.rb
+++ b/libimagruby/tests/test_methods_present.rb
@@ -10,13 +10,13 @@ class BasicImagInterfaceTest < Minitest::Test
   end
 
   def test_constants_exist
-    [ :Logger
-    , :StoreId
-    , :StoreHandle
-    , :FileLockEntryHandle
-    , :EntryHeader
-    , :EntryContent
-    , :VERSION
+    [ :Logger,
+      :StoreId,
+      :StoreHandle,
+      :FileLockEntryHandle,
+      :EntryHeader,
+      :EntryContent,
+      :VERSION
     ].each do |k|
       assert Imag.constants.include? k
     end

--- a/libimagruby/tests/test_methods_present.rb
+++ b/libimagruby/tests/test_methods_present.rb
@@ -28,5 +28,57 @@ class BasicImagInterfaceTest < Minitest::Test
     end
   end
 
+  def test_file_lock_entry_handle_methods_exist
+    [ :get_location
+    , :get_header
+    , :set_header
+    , :get_content
+    , :set_content
+    ].each do |m|
+      assert Imag::FileLockEntryHandle.methods.include? m
+    end
+  end
+
+  def test_entry_header_methods_exist
+    [ :new
+    , :insert
+    , :set
+    , :get
+    ].each do |m|
+      assert Imag::EntryHeader.methods.include? m
+    end
+  end
+
+  def test_store_handle_methods_exist
+    [ :new
+    , :create
+    , :retrieve
+    , :get
+    , :retrieve_for_module
+    , :update
+    , :delete
+    , :save_to
+    , :save_as
+    , :move_by_id
+    , :path
+    ].each do |m|
+      assert Imag::StoreHandle.methods.include? m
+    end
+  end
+
+  def test_storeid_methods_exist
+    [ :new
+    , :new_baseless
+    , :without_base
+    , :with_base
+    , :into_pathbuf
+    , :exists
+    , :to_str
+    , :local
+    ].each do |m|
+      assert Imag::StoreId.methods.include? m
+    end
+  end
+
 end
 

--- a/libimagruby/tests/test_methods_present.rb
+++ b/libimagruby/tests/test_methods_present.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'imag'
+require 'minitest/autorun'
+
+class BasicImagInterfaceTest < Minitest::Test
+
+  def setup
+    # nothing
+  end
+
+  def test_logger_methods_exist
+    [:init, :trace, :dbg, :debug, :info, :warn, :error].each do |m|
+      assert Imag::Logger.methods.include? m
+    end
+  end
+
+end
+

--- a/libimagruby/tests/test_methods_present.rb
+++ b/libimagruby/tests/test_methods_present.rb
@@ -29,52 +29,52 @@ class BasicImagInterfaceTest < Minitest::Test
   end
 
   def test_file_lock_entry_handle_methods_exist
-    [ :get_location
-    , :get_header
-    , :set_header
-    , :get_content
-    , :set_content
+    [ :get_location,
+      :get_header,
+      :set_header,
+      :get_content,
+      :set_content
     ].each do |m|
       assert Imag::FileLockEntryHandle.methods.include? m
     end
   end
 
   def test_entry_header_methods_exist
-    [ :new
-    , :insert
-    , :set
-    , :get
+    [ :new,
+      :insert,
+      :set,
+      :get
     ].each do |m|
       assert Imag::EntryHeader.methods.include? m
     end
   end
 
   def test_store_handle_methods_exist
-    [ :new
-    , :create
-    , :retrieve
-    , :get
-    , :retrieve_for_module
-    , :update
-    , :delete
-    , :save_to
-    , :save_as
-    , :move_by_id
-    , :path
+    [ :new,
+      :create,
+      :retrieve,
+      :get,
+      :retrieve_for_module,
+      :update,
+      :delete,
+      :save_to,
+      :save_as,
+      :move_by_id,
+      :path
     ].each do |m|
       assert Imag::StoreHandle.methods.include? m
     end
   end
 
   def test_storeid_methods_exist
-    [ :new
-    , :new_baseless
-    , :without_base
-    , :with_base
-    , :into_pathbuf
-    , :exists
-    , :to_str
-    , :local
+    [ :new,
+      :new_baseless,
+      :without_base,
+      :with_base,
+      :into_pathbuf,
+      :exists,
+      :to_str,
+      :local
     ].each do |m|
       assert Imag::StoreId.methods.include? m
     end

--- a/libimagruby/tests/test_store_crud.rb
+++ b/libimagruby/tests/test_store_crud.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+
+require 'imag'
+require 'minitest/autorun'
+
+class StoreCRUDTest < Minitest::Test
+
+  def setup
+    Imag::Logger.init debug: true, verbose: true, color: false
+    @store = Imag::StoreHandle.new true, "/tmp/"
+  end
+
+  def teardown
+    @store = nil
+  end
+
+  def test_store_path
+    assert_equal "/tmp/store", @store.path
+  end
+
+  def test_getting_nonexistent_id
+    id = Imag::StoreId::new_baseless "nonexistent"
+    assert_raises RImagStoreReadError do
+      @store.get id
+    end
+  end
+
+  def test_create
+    id = Imag::StoreId::new_baseless "created"
+    fle = @store.create id
+
+    assert_instance_of FileLockEntry, fle
+    assert_equal "/tmp/store/created", fle.location
+  end
+
+  def test_retrieve_new
+    id = Imag::StoreId::new_baseless "retrieved_new"
+    fle = @store.retrieve id
+
+    assert_instance_of FileLockEntry, fle
+    assert_equal "/tmp/store/retrieved_new", fle.location
+  end
+
+  def test_retrieve_old
+    id = Imag::StoreId::new_baseless "retrieve_old"
+    @store.create id
+
+    fle = @store.retrieve id
+
+    assert_instance_of FileLockEntry, fle
+    assert_equal "/tmp/store/retrieved_old", fle.location
+  end
+
+  def test_delete_nonexistent
+    id = Imag::StoreId::new_baseless "delete_nonexist"
+
+    assert_raises RImagStoreWriteError do
+      @store.delete id
+    end
+  end
+
+  def test_delete_existent
+    id = Imag::StoreId::new_baseless "delete_exist"
+
+    @store.create id
+    assert_nil @store.delete(id)
+  end
+
+end
+


### PR DESCRIPTION
Add a testing setup. 

Closes #870 (superceeded)

---

- [x] Cherry-picked commit from #888 should be removed before merging.
- [x] Based on #871 right now. Should rebase before merging.

---

@malept this currently fails, can you tell why?

```
$ bundle exec rake thermite:test
checking for cargo... yes
/nix/store/3b1qps1ixm60vsy1i4f48g6360vjg8d0-cargo-0.15.0/bin/cargo test
error: manifest path `/home/m/archive/development/rust/imag/Cargo.toml` is a virtual manifest, but this command requires running against an actual package in this workspace
rake aborted!
Command failed with status (101): [/nix/store/3b1qps1ixm60vsy1i4f48g6360vjg8d...]
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:42:in `block in run_cargo'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:40:in `chdir'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:40:in `run_cargo'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:50:in `run_cargo_if_exists'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/tasks.rb:143:in `block in define_test_task'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `load'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `kernel_load'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:27:in `run'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli.rb:332:in `exec'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli.rb:20:in `dispatch'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli.rb:11:in `start'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/exe/bundle:34:in `block in <top (required)>'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/exe/bundle:26:in `<top (required)>'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/bin/bundle:18:in `load'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/bin/bundle:18:in `<main>'
Tasks: TOP => thermite:test
(See full trace by running task with --trace)



bundle exec rake test
checking for cargo... yes
/nix/store/3b1qps1ixm60vsy1i4f48g6360vjg8d0-cargo-0.15.0/bin/cargo rustc --manifest-path libimagruby/Cargo.toml --release
    Finished release [optimized] target(s) in 0.0 secs
/nix/store/3b1qps1ixm60vsy1i4f48g6360vjg8d0-cargo-0.15.0/bin/cargo test
error: manifest path `/home/m/archive/development/rust/imag/Cargo.toml` is a virtual manifest, but this command requires running against an actual package in this workspace
rake aborted!
Command failed with status (101): [/nix/store/3b1qps1ixm60vsy1i4f48g6360vjg8d...]
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:42:in `block in run_cargo'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:40:in `chdir'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:40:in `run_cargo'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/cargo.rb:50:in `run_cargo_if_exists'
/home/m/archive/development/rust/imag/libimagruby/vendor/bundle/ruby/2.3.0/gems/thermite-0.11.0/lib/thermite/tasks.rb:143:in `block in define_test_task'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `load'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `kernel_load'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:27:in `run'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli.rb:332:in `exec'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli.rb:20:in `dispatch'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/cli.rb:11:in `start'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/exe/bundle:34:in `block in <top (required)>'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/lib/ruby/gems/2.3.0/gems/bundler-1.13.7/exe/bundle:26:in `<top (required)>'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/bin/bundle:18:in `load'
/nix/store/sznvnn582dqxl1v1fsciywdbw8984271-bundler-1.13.7/bin/bundle:18:in `<main>'
Tasks: TOP => test => thermite:test
(See full trace by running task with --trace)

```
