### PR TITLE
Make clap version more specific

### DIFF
--- a/libimagentrylist/Cargo.toml
+++ b/libimagentrylist/Cargo.toml
@@ -14,7 +14,7 @@ repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
 [dependencies]
-clap = "2.*"
+clap = ">=2.17"
 log = "0.3"
 toml = "0.2.*"
 prettytable-rs = "0.6.*"


### PR DESCRIPTION
Small bump.

We don't need to force the newest version (2.20.5 as of writing), as cargo does this for us, so I won't bump the version here.