### PR TITLE
Makefile use workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ LIB_TARGETS_TEST=$(foreach x,$(subst ./,,$(LIBS)),$(x)-test)
 TARGETS=$(BIN_TARGETS) $(LIB_TARGETS)
 RELEASE_TARGETS=$(foreach x,$(TARGETS),$(x)-release)
 INSTALL_TARGETS=$(foreach x,$(BIN_TARGETS),$(x)-install)
-UPDATE_TARGETS=$(foreach x,$(TARGETS),$(x)-update)
-CLEAN_TARGETS=$(foreach x,$(TARGETS),$(x)-clean)
 CHECK_TARGETS=$(foreach x,$(TARGETS),$(x)-check)
 CHECK_OUTDATED_TARGETS=$(foreach x,$(TARGETS),$(x)-check-outdated)
 
@@ -37,10 +35,6 @@ imag-bin-release:
 imag-bin-install:
 	@$(ECHO) "\t[IMAG   ][INSTALL]"
 	@$(CARGO) install --force --path ./bin
-
-imag-bin-clean:
-	@$(ECHO) "\t[IMAG   ][CLEAN  ]"
-	@$(CARGO) clean --manifest-path ./bin/Cargo.toml
 
 imag-bin-check:
 	@$(ECHO) "\t[IMAG   ][CHECK  ]"
@@ -75,8 +69,9 @@ update:
 	@$(ECHO) "\t[UPDATE ]"
 	@$(CARGO) update
 
-clean: $(CLEAN_TARGETS) imag-bin-clean
+clean:
 	@$(ECHO) "\t[CLEAN  ]"
+	@$(CARGO) clean
 
 check: $(CHECK_TARGETS) imag-bin-check
 
@@ -103,10 +98,6 @@ $(LIB_TARGETS_TEST): %: .FORCE
 $(INSTALL_TARGETS): %: .FORCE imag-bin-install
 	@$(ECHO) "\t[INSTALL]:\t$(subst -install,,$@)"
 	@$(CARGO) install --force --path ./$(subst -install,,$@)
-
-$(CLEAN_TARGETS): %: .FORCE
-	@$(ECHO) "\t[CLEAN  ]:\t$(subst -clean,,$@)"
-	@$(CARGO) clean --manifest-path ./$(subst -clean,,$@)/Cargo.toml
 
 $(CHECK_TARGETS): %: .FORCE
 	@$(ECHO) "\t[CHECK  ]:\t$(subst -check,,$@)"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ TARGETS=$(BIN_TARGETS) $(LIB_TARGETS)
 RELEASE_TARGETS=$(foreach x,$(TARGETS),$(x)-release)
 INSTALL_TARGETS=$(foreach x,$(BIN_TARGETS),$(x)-install)
 CHECK_TARGETS=$(foreach x,$(TARGETS),$(x)-check)
-CHECK_OUTDATED_TARGETS=$(foreach x,$(TARGETS),$(x)-check-outdated)
 
 all: $(TARGETS) imag-bin
 	@$(ECHO) "\t[ALL    ]"
@@ -39,10 +38,6 @@ imag-bin-install:
 imag-bin-check:
 	@$(ECHO) "\t[IMAG   ][CHECK  ]"
 	@$(CARGO) check --manifest-path ./bin/Cargo.toml
-
-imag-bin-check-outdated:
-	@$(ECHO) "\t[IMAG   ][CHECK  ]"
-	@$(CARGO) outdated --manifest-path ./bin/Cargo.toml --lockfile-path ./bin/Cargo.lock
 
 release: $(RELEASE_TARGETS) imag-bin-release
 	@$(ECHO) "\t[RELEASE]"
@@ -75,7 +70,9 @@ clean:
 
 check: $(CHECK_TARGETS) imag-bin-check
 
-check-outdated: $(CHECK_OUTDATED_TARGETS) imag-bin-check-outdated
+check-outdated:
+	@$(ECHO) "\t[OUTDATED]"
+	@$(CARGO) outdated
 
 $(TARGETS): %: .FORCE
 	@$(ECHO) "\t[CARGO  ]:\t$@"
@@ -102,12 +99,6 @@ $(INSTALL_TARGETS): %: .FORCE imag-bin-install
 $(CHECK_TARGETS): %: .FORCE
 	@$(ECHO) "\t[CHECK  ]:\t$(subst -check,,$@)"
 	@$(CARGO) check --manifest-path ./$(subst -check,,$@)/Cargo.toml
-
-$(CHECK_OUTDATED_TARGETS): %: .FORCE $(subst -check-outdated,-update,$@)
-	@$(ECHO) "\t[OUTDATE]:\t$(subst -check-outdated,,$@)"
-	@$(CARGO) outdated -R										  \
-		--manifest-path $(PWD)/$(subst -check-outdated,,$@)/Cargo.toml \
-		--lockfile-path $(PWD)/$(subst -check-outdated,,$@)/Cargo.lock
 
 .FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,6 @@ imag-bin-release:
 	@$(ECHO) "\t[IMAG   ][RELEASE]"
 	@$(CARGO) build --release --manifest-path ./bin/Cargo.toml
 
-imag-bin-update:
-	@$(ECHO) "\t[IMAG   ][UPDATE ]"
-	@$(CARGO) update --manifest-path ./bin/Cargo.toml
-
 imag-bin-install:
 	@$(ECHO) "\t[IMAG   ][INSTALL]"
 	@$(CARGO) install --force --path ./bin
@@ -75,8 +71,9 @@ test: bin-test lib-test
 install: $(INSTALL_TARGETS) imag-bin-install
 	@$(ECHO) "\t[INSTALL]"
 
-update: $(UPDATE_TARGETS) imag-bin-update
+update:
 	@$(ECHO) "\t[UPDATE ]"
+	@$(CARGO) update
 
 clean: $(CLEAN_TARGETS) imag-bin-clean
 	@$(ECHO) "\t[CLEAN  ]"
@@ -106,10 +103,6 @@ $(LIB_TARGETS_TEST): %: .FORCE
 $(INSTALL_TARGETS): %: .FORCE imag-bin-install
 	@$(ECHO) "\t[INSTALL]:\t$(subst -install,,$@)"
 	@$(CARGO) install --force --path ./$(subst -install,,$@)
-
-$(UPDATE_TARGETS): %: .FORCE
-	@$(ECHO) "\t[UPDATE ]:\t$(subst -update,,$@)"
-	@$(CARGO) update --manifest-path ./$(subst -update,,$@)/Cargo.toml
 
 $(CLEAN_TARGETS): %: .FORCE
 	@$(ECHO) "\t[CLEAN  ]:\t$(subst -clean,,$@)"

--- a/README.md
+++ b/README.md
@@ -50,18 +50,19 @@ might think!
 
 There are several targets for each of the sub-crates in the Makefile:
 
-| Target   | Multi | Purpose                                  | Example         |
-| :---     | ----- | :---                                     | :---            |
-| all      |       | Build everything, debug mode             | `make all`      |
-| bin      |       | Build all binaries, debug mode           | `make bin`      |
-| lib      |       | Build all libraries, debug mode          | `make lib`      |
-| lib-test |       | Test all libraries                       | `make lib-test` |
-| imag-bin |       | Build only the `imag` binary, debug mode | `make imag-bin` |
-| check    | *     | Run `cargo check`                        | `make check`    |
-| clean    | *     | Remove build artifacts                   | `make clean`    |
-| install  | *     | Build everything, release mode, install  | `make install`  |
-| release  | *     | Build everything, release mode           | `make release`  |
-| update   | *     | Run `cargo update`                       | `make update`   |
+| Target         | Multi | Purpose                                  | Example              |
+| :---           | ----- | :---                                     | :---                 |
+| all            |       | Build everything, debug mode             | `make all`           |
+| bin            |       | Build all binaries, debug mode           | `make bin`           |
+| lib            |       | Build all libraries, debug mode          | `make lib`           |
+| lib-test       |       | Test all libraries                       | `make lib-test`      |
+| imag-bin       |       | Build only the `imag` binary, debug mode | `make imag-bin`      |
+| clean          |       | Remove build artifacts                   | `make clean`         |
+| update         |       | Run `cargo update`                       | `make update`        |
+| check-outdated |       | Run `cargo outdated`                     | `make check-outdated`|
+| check          | *     | Run `cargo check`                        | `make check`         |
+| install        | *     | Build everything, release mode, install  | `make install`       |
+| release        | *     | Build everything, release mode           | `make release`       |
 
 The `Multi` targets are callable for each sub-crate. For example you can call
 `make imag-store-check` to run `cargo check` on the `imag-store` crate.


### PR DESCRIPTION
With the introduction of workspaces, some things became sort-of wrong in the Makefile. E.g. running `make clean` would clean `$IMAG/target` as many times as crates are specified in the the `members` section in `$IMAG/Cargo.toml`.
AFAIK, the same applies to `cargo outdated` and `cargo update`.
Please review/test to make sure I'm not wrong 😄 