### PR TITLE
travis: IRC notifications fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ notifications:
     on_success: never
   irc:
     channels:
-    - chat.freenode.net#imag
+      - chat.freenode.net#imag
     template:
-    - "%{repository_name} (%{branch} @ %{commit} by %{author}): %{result}"
+      - "%{repository_name} (%{branch} @ %{commit} by %{author}): %{result}"
 
 env:
   global:


### PR DESCRIPTION
I guess travis does not send irc notifications anymore because the indentation is wrong here... I don't know for sure, though.