### PR TITLE
libimagrt: cleanup

### DIFF
--- a/libimagrt/Cargo.toml
+++ b/libimagrt/Cargo.toml
@@ -22,6 +22,7 @@ xdg-basedir = "1.0"
 itertools = "0.5"
 tempfile = "2.1"
 ansi_term = "0.9"
+is-match = "0.1"
 
 [dependencies.libimagstore]
 path = "../libimagstore"

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -165,9 +165,9 @@ fn into_value(value: Value, s: String) -> Option<Value> {
     use std::str::FromStr;
 
     match value {
-        Value::String(_) => Some(Value::String(s)),
-        Value::Integer(_) => FromStr::from_str(&s[..]).ok().map(|i| Value::Integer(i)),
-        Value::Float(_) => FromStr::from_str(&s[..]).ok().map(|f| Value::Float(f)),
+        Value::String(_)  => Some(Value::String(s)),
+        Value::Integer(_) => FromStr::from_str(&s[..]).ok().map(Value::Integer),
+        Value::Float(_)   => FromStr::from_str(&s[..]).ok().map(Value::Float),
         Value::Boolean(_) => {
             if s == "true" { Some(Value::Boolean(true)) }
             else if s == "false" { Some(Value::Boolean(false)) }

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -97,7 +97,6 @@ impl Configuration {
         self.editor.as_ref()
     }
 
-    #[allow(dead_code)] // Why do I actually need this annotation on a pub function?
     /// Get the underlying configuration TOML object
     pub fn config(&self) -> &Value {
         &self.config

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -245,7 +245,7 @@ fn fetch_config(rtp: &PathBuf) -> Result<Value> {
     ].iter()
         .flatten()
         .filter(|path| path.exists() && path.is_file())
-        .map(|path| {
+        .filter_map(|path| if path.exists() && path.is_file() {
             debug!("Reading {:?}", path);
             let content = {
                 let mut s = String::new();
@@ -266,8 +266,9 @@ fn fetch_config(rtp: &PathBuf) -> Result<Value> {
                 .map_err(|e| REK::Instantiate.into_error_with_cause(e));
 
             Some(toml)
+        } else {
+            None
         })
-        .filter_map(|x| x)
         .filter(|loaded| loaded.is_ok())
         .map(|inner| Value::Table(inner.unwrap()))
         .nth(0)

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -190,7 +190,7 @@ impl Deref for Configuration {
 fn get_verbosity(v: &Value) -> bool {
     match *v {
         Value::Table(ref t) => t.get("verbose")
-                .map_or(false, |v| match *v { Value::Boolean(b) => b, _ => false, }),
+                .map_or(false, |v| is_match!(v, &Value::Boolean(true))),
         _ => false,
     }
 }

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -128,13 +128,11 @@ impl Configuration {
 
         v.into_iter()
             .map(|s| { debug!("Trying to process '{}'", s); s })
-            .filter_map(|s| {
-                match s.into_kv() {
-                    Some(kv) => Some(kv.into()),
-                    None => {
-                        warn!("Could split at '=' - will be ignore override");
-                        None
-                    }
+            .filter_map(|s| match s.into_kv() {
+                Some(kv) => Some(kv.into()),
+                None => {
+                    warn!("Could split at '=' - will be ignore override");
+                    None
                 }
             })
             .map(|(k, v)| {

--- a/libimagrt/src/configuration.rs
+++ b/libimagrt/src/configuration.rs
@@ -135,23 +135,21 @@ impl Configuration {
                     None
                 }
             })
-            .map(|(k, v)| {
-                self.config
-                    .read(&k[..])
-                    .map_err_into(CEK::TOMLParserError)
-                    .map(|toml| match toml {
-                        Some(value) => {
-                            match into_value(value, v) {
-                                Some(v) => {
-                                    info!("Successfully overridden: {} = {}", k, v);
-                                    Ok(v)
-                                },
-                                None => Err(CEK::ConfigOverrideTypeNotMatching.into_error()),
-                            }
+            .map(|(k, v)| self
+                 .config
+                 .read(&k[..])
+                 .map_err_into(CEK::TOMLParserError)
+                 .map(|toml| match toml {
+                    Some(value) => match into_value(value, v) {
+                        Some(v) => {
+                            info!("Successfully overridden: {} = {}", k, v);
+                            Ok(v)
                         },
-                        None => Err(CEK::ConfigOverrideKeyNotAvailable.into_error()),
-                    })
-            })
+                        None => Err(CEK::ConfigOverrideTypeNotMatching.into_error()),
+                    },
+                    None => Err(CEK::ConfigOverrideKeyNotAvailable.into_error()),
+                })
+            )
             .fold_result(|i| i)
             .map_err(Box::new)
             .map_err(|e| CEK::ConfigOverrideError.into_error_with_cause(e))

--- a/libimagrt/src/lib.rs
+++ b/libimagrt/src/lib.rs
@@ -42,6 +42,7 @@ extern crate ansi_term;
 
 extern crate clap;
 extern crate toml;
+#[macro_use] extern crate is_match;
 
 extern crate libimagstore;
 extern crate libimagutil;

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -310,9 +310,7 @@ impl<'a> Runtime<'a> {
                 debug!("Init logger with {}", lvl);
                 Box::new(ImagLogger::new(lvl.to_log_level().unwrap()).with_color(colored))
             })
-            .map_err(|_| {
-                panic!("Could not setup logger");
-            })
+            .map_err(|e| panic!("Could not setup logger: {:?}", e))
             .ok();
         }
     }

--- a/libimagrt/src/runtime.rs
+++ b/libimagrt/src/runtime.rs
@@ -394,11 +394,9 @@ impl<'a> Runtime<'a> {
         self.cli()
             .value_of("editor")
             .map(String::from)
-            .or({
-                match self.configuration {
-                    Some(ref c) => c.editor().cloned(),
-                    _ => None,
-                }
+            .or(match self.configuration {
+                Some(ref c) => c.editor().cloned(),
+                _ => None,
             })
             .or(env::var("EDITOR").ok())
             .map(Command::new)


### PR DESCRIPTION
Some cleanup in the `libimagrt` codebase.

I'll wait for #947 before merging this.