### PR TITLE
Add missing license headers

### DIFF
--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,3 +1,22 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
 extern crate clap;
 extern crate libimagrt;
 extern crate libimagentrytag;

--- a/libimagutil/src/cli_validators.rs
+++ b/libimagutil/src/cli_validators.rs
@@ -1,3 +1,22 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
 //! Functions to be used for clap::Arg::validator()
 //! to validate arguments
 

--- a/libimagutil/src/iter.rs
+++ b/libimagutil/src/iter.rs
@@ -1,3 +1,4 @@
+//
 // imag - the personal information management suite for the commandline
 // Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
 //


### PR DESCRIPTION
We had quite some files where we had no license header I noticed. This fixes it.