### PR TITLE
Make libimagstore::file_abstraction pub

### DIFF
--- a/libimagstore/src/lib.rs
+++ b/libimagstore/src/lib.rs
@@ -54,6 +54,6 @@ pub mod storeid;
 pub mod error;
 pub mod store;
 mod configuration;
-mod file_abstraction;
+pub mod file_abstraction;
 pub mod toml_ext;
 


### PR DESCRIPTION
This makes the `file_abstraction` module pub.

We need this to be able to use the in-memory backend when using the store in tests.

As this module itself only exports the required parts, we can export the whole module instead of reexporting its types in `libimagstore::store` or whatever.

Relevant for @irobert91 as well!