### PR TITLE
Libimagstore/io backend knows format

### DIFF
--- a/doc/src/02000-store.md
+++ b/doc/src/02000-store.md
@@ -201,12 +201,6 @@ The `InMemoryFileAbstractionInstance` implementation is corrosponding to
 the `InMemoryFileAbstraction` implementation - for the in-memory
 "filesystem".
 
-The implementation of the `get_file_content()` function had to be
-changed to return a `String` rather than a `&mut Read` because of
-lifetime issues.
-This change is store-internally and the API of the store itself was not
-affected.
-
 ## The StdIo backend {#sec:thestore:backends:stdio}
 
 Sidenote: The name is "StdIo" because its main purpose is Stdin/Stdio, but it
@@ -231,41 +225,28 @@ implementation are possible.
 
 The following section assumes a JSON mapper.
 
-The backends themselves do not know "header" and "content" - they know only
-blobs which live in pathes.
-Indeed, this "backend" code does not serve "content" or "header" to the `Store`
-implementation, but only a blob of bytes.
-Anyways, the JSON-protocol for passing a store around _does_ know about content
-and header (see @sec:thestore:backends:stdio:json for the JSON format).
-
-So the mapper reads the JSON, parses it (thanks serde!) and translates it to
-TOML, because TOML is the Store representation of a header.
-But because the backend does not serve header and content, but only a blob,
-this TOML is then translated (with the content of the respective file) to a
-blob.
+The mapper reads the JSON, parses it (thanks serde!) and translates it to
+a `Entry`, which is the in-memory representation of the files.
+The `Entry` contains a `Header` part and a `Content` part.
 
 This is then made available to the store codebase.
-This is complex and probably slow, we know.
 
 To summarize what we do right now, lets have a look at the awesome ascii-art
 below:
 
 ```
-                            libimag*
-                               |
-                               v
- IO     Mapper        FS     Store      FS         Mapper     IO
-+--+-------------+---------+--------+---------+--------------+--+
-|  |             |         |        |         |              |  |
-    JSON -> TOML -> String -> Entry -> String -> TOML -> JSON
-                              + TOML
-                              + Content
+                    libimag*
+                       |
+                       v
+ IO   Mapper         Store      Mapper  IO
++--+---------+----------------+--------+--+
+|  |         |                |        |  |
+    JSON     ->    Entry     ->  JSON
+                   + Header
+                   + Content
 ```
 
 This is what gets translated where for one imag call with a stdio store backend.
-
-The rationale behind this implementation is that this is the best implementation
-we can have in a relatively short amount of time.
 
 ### The JSON Mapper {#sec:thestore:backends:stdio:json}
 
@@ -278,7 +259,7 @@ The strucure is as follows:
 {
     "version": "0.3.0",
     "store": {
-        "/example": {
+        "example": {
             "header": {
                 "imag": {
                     "version": "0.3.0",
@@ -292,24 +273,14 @@ The strucure is as follows:
 
 ### TODO {#sec:thestore:backends:todo}
 
-Of course, the above is not optimal.
-The TODO here is almost visible: Implement a proper backend where we do not need
-to translate between types all the time.
+If you look at the version history of this file you will see that this
+implementation has grown from something complex and probably slow to what we
+have today.
 
-The first goal would be to reduce the above figure to:
-
-```
-           libimag*
-              |
-              v
- IO Mapper  Store    Mapper IO
-+--+------+--------+-------+--+
-|  |      |        |       |  |
-    JSON -> Entry -> JSON
-            + TOML
-            + Content
-```
-
-and the second step would be to abstract all the things away so the `libimag*`
-crates handle the header without knowing whether it is JSON or TOML.
+Still, there's one improvement we could make: abstract all the things away so
+the `libimag*` crates handle the header without knowing whether it is JSON or
+TOML.
+With this, we would not even have to translate JSON to TOML anymore.
+We should measure whether this would have actually any performance impact before
+implementing it.
 

--- a/libimagstore/src/file_abstraction/inmemory.rs
+++ b/libimagstore/src/file_abstraction/inmemory.rs
@@ -19,8 +19,6 @@
 
 use error::StoreError as SE;
 use error::StoreErrorKind as SEK;
-use std::io::Read;
-use std::io::Cursor;
 use std::path::PathBuf;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -31,11 +29,10 @@ use libimagerror::into::IntoError;
 
 use super::FileAbstraction;
 use super::FileAbstractionInstance;
-use error::MapErrInto;
 use store::Entry;
 use storeid::StoreId;
 
-type Backend = Arc<Mutex<RefCell<HashMap<PathBuf, Cursor<Vec<u8>>>>>>;
+type Backend = Arc<Mutex<RefCell<HashMap<PathBuf, Entry>>>>;
 
 /// `FileAbstraction` type, this is the Test version!
 ///
@@ -62,22 +59,16 @@ impl FileAbstractionInstance for InMemoryFileAbstractionInstance {
     /**
      * Get the mutable file behind a InMemoryFileAbstraction object
      */
-    fn get_file_content(&mut self, id: StoreId) -> Result<Entry, SE> {
+    fn get_file_content(&mut self, _: StoreId) -> Result<Entry, SE> {
         debug!("Getting lazy file: {:?}", self);
 
         let p = self.absent_path.clone();
         match self.fs_abstraction.lock() {
             Ok(mut mtx) => {
                 mtx.get_mut()
-                    .get_mut(&p)
+                    .get(&p)
+                    .cloned()
                     .ok_or(SEK::FileNotFound.into_error())
-                    .and_then(|t| {
-                        let mut s = String::new();
-                        t.read_to_string(&mut s)
-                            .map_err_into(SEK::IoError)
-                            .map(|_| s)
-                            .and_then(|s| Entry::from_str(id, &s))
-                    })
             }
 
             Err(_) => Err(SEK::LockError.into_error())
@@ -85,20 +76,11 @@ impl FileAbstractionInstance for InMemoryFileAbstractionInstance {
     }
 
     fn write_file_content(&mut self, buf: &Entry) -> Result<(), SE> {
-        let buf = buf.to_str().into_bytes();
         match *self {
             InMemoryFileAbstractionInstance { ref absent_path, .. } => {
                 let mut mtx = self.fs_abstraction.lock().expect("Locking Mutex failed");
                 let mut backend = mtx.get_mut();
-
-                if let Some(ref mut cur) = backend.get_mut(absent_path) {
-                    let mut vec = cur.get_mut();
-                    vec.clear();
-                    vec.extend_from_slice(&buf);
-                    return Ok(());
-                }
-                let vec = Vec::from(buf);
-                backend.insert(absent_path.clone(), Cursor::new(vec));
+                let _ = backend.insert(absent_path.clone(), buf.clone());
                 return Ok(());
             },
         };

--- a/libimagstore/src/file_abstraction/stdio/mapper/mod.rs
+++ b/libimagstore/src/file_abstraction/stdio/mapper/mod.rs
@@ -18,14 +18,14 @@
 //
 
 use std::collections::HashMap;
-use std::io::Cursor;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use store::Result;
+use store::Entry;
 
 pub trait Mapper {
-    fn read_to_fs<R: Read>(&self, &mut R, &mut HashMap<PathBuf, Cursor<Vec<u8>>>)   -> Result<()>;
-    fn fs_to_write<W: Write>(&self, &mut HashMap<PathBuf, Cursor<Vec<u8>>>, &mut W) -> Result<()>;
+    fn read_to_fs<R: Read>(&self, &mut R, &mut HashMap<PathBuf, Entry>)   -> Result<()>;
+    fn fs_to_write<W: Write>(&self, &mut HashMap<PathBuf, Entry>, &mut W) -> Result<()>;
 }
 
 pub mod json;

--- a/libimagstore/src/file_abstraction/stdio/mod.rs
+++ b/libimagstore/src/file_abstraction/stdio/mod.rs
@@ -23,7 +23,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Error as FmtError;
 use std::fmt::Formatter;
-use std::io::Cursor;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -37,12 +36,13 @@ use error::StoreError as SE;
 use super::FileAbstraction;
 use super::FileAbstractionInstance;
 use super::InMemoryFileAbstraction;
+use store::Entry;
 
 pub mod mapper;
 use self::mapper::Mapper;
 
 // Because this is not exported in super::inmemory;
-type Backend = Arc<Mutex<RefCell<HashMap<PathBuf, Cursor<Vec<u8>>>>>>;
+type Backend = Arc<Mutex<RefCell<HashMap<PathBuf, Entry>>>>;
 
 pub struct StdIoFileAbstraction<W: Write, M: Mapper> {
     mapper: M,
@@ -83,7 +83,7 @@ impl<W, M> StdIoFileAbstraction<W, M>
     }
 
     pub fn backend(&self) -> &Backend {
-        &self.mem.backend()
+        self.mem.backend()
     }
 
 }

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -158,13 +158,11 @@ impl StoreEntry {
     }
 
     fn get_entry(&mut self) -> Result<Entry> {
-        let id = &self.id.clone();
         if !self.is_borrowed() {
             self.file
-                .get_file_content()
-                .and_then(|content| Entry::from_str(id.clone(), &content))
+                .get_file_content(self.id.clone())
                 .or_else(|err| if err.err_type() == SEK::FileNotFound {
-                    Ok(Entry::new(id.clone()))
+                    Ok(Entry::new(self.id.clone()))
                 } else {
                     Err(err)
                 })
@@ -176,7 +174,7 @@ impl StoreEntry {
     fn write_entry(&mut self, entry: &Entry) -> Result<()> {
         if self.is_borrowed() {
             assert_eq!(self.id, entry.location);
-            self.file.write_file_content(entry.to_str().as_bytes())
+            self.file.write_file_content(entry)
                 .map_err_into(SEK::FileError)
                 .map(|_| ())
         } else {


### PR DESCRIPTION
Changes the backend to know what an `Entry` is. This way, we do one `TOML->String->TOML` conversion less for each entry.

:tada: 