### PR TITLE
Libimagstore/backend replacement

### DIFF
--- a/libimagstore/src/file_abstraction/stdio/mod.rs
+++ b/libimagstore/src/file_abstraction/stdio/mod.rs
@@ -35,6 +35,7 @@ use error::StoreErrorKind as SEK;
 use error::StoreError as SE;
 use super::FileAbstraction;
 use super::FileAbstractionInstance;
+use super::Drain;
 use super::InMemoryFileAbstraction;
 use store::Entry;
 
@@ -113,6 +114,14 @@ impl<W: Write, M: Mapper> FileAbstraction for StdIoFileAbstraction<W, M> {
 
     fn new_instance(&self, p: PathBuf) -> Box<FileAbstractionInstance> {
         self.0.new_instance(p)
+    }
+
+    fn drain(&self) -> Result<Drain, SE> {
+        self.0.drain()
+    }
+
+    fn fill(&mut self, d: Drain) -> Result<(), SE> {
+        self.0.fill(d)
     }
 }
 

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -315,11 +315,6 @@ impl Store {
     /// to stdout, we need to be able to replace the in-memory backend with the real filesystem
     /// backend.
     ///
-    /// # TODO
-    ///
-    /// Currently, this is the naive implementatoin which does not transfer contents of the
-    /// backends.
-    ///
     pub fn reset_backend(&mut self, mut backend: Box<FileAbstraction>) -> Result<()> {
         self.backend
             .drain()

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -320,9 +320,11 @@ impl Store {
     /// Currently, this is the naive implementatoin which does not transfer contents of the
     /// backends.
     ///
-    pub fn reset_backend(&mut self, backend: Box<FileAbstraction>) -> Result<()> {
-        self.backend = backend;
-        Ok(())
+    pub fn reset_backend(&mut self, mut backend: Box<FileAbstraction>) -> Result<()> {
+        self.backend
+            .drain()
+            .and_then(|drain| backend.fill(drain))
+            .map(|_| self.backend = backend)
     }
 
     /// Get the store configuration

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -295,6 +295,36 @@ impl Store {
         Ok(store)
     }
 
+    /// Reset the backend of the store during runtime
+    ///
+    /// # Warning
+    ///
+    /// This is dangerous!
+    /// You should not be able to do that in application code, only the libimagrt should be used to
+    /// do this via safe and careful wrapper functions!
+    ///
+    /// If you are able to do this without using `libimagrt`, please file an issue report.
+    ///
+    /// # Purpose
+    ///
+    /// With the I/O backend of the store, the store is able to pipe itself out via (for example)
+    /// JSON. But because we need a functionality where we load contents from the filesystem and
+    /// then pipe it to stdout, we need to be able to replace the backend during runtime.
+    ///
+    /// This also applies the other way round: If we get the store from stdin and have to persist it
+    /// to stdout, we need to be able to replace the in-memory backend with the real filesystem
+    /// backend.
+    ///
+    /// # TODO
+    ///
+    /// Currently, this is the naive implementatoin which does not transfer contents of the
+    /// backends.
+    ///
+    pub fn reset_backend(&mut self, backend: Box<FileAbstraction>) -> Result<()> {
+        self.backend = backend;
+        Ok(())
+    }
+
     /// Get the store configuration
     pub fn config(&self) -> Option<&Value> {
         self.configuration.as_ref()


### PR DESCRIPTION
This implements backend draining, which can be used to start the store with one backend and close it with another.

Purpose: Reading from the filesystem store to stdout.