### PR TITLE
Imag store dump

### DIFF
--- a/imag-store/src/dump.rs
+++ b/imag-store/src/dump.rs
@@ -39,7 +39,7 @@ pub fn dump(rt: &mut Runtime) {
         });
 
     if let Ok(_) = cachingres {
-        if let Err(_) = rt.store_backend_to_stdio().map_err_trace() {
+        if let Err(_) = rt.store_backend_to_stdout().map_err_trace() {
             error!("Loading Store IO backend failed");
             exit(1);
         }

--- a/imag-store/src/dump.rs
+++ b/imag-store/src/dump.rs
@@ -1,0 +1,23 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+pub fn dump(rt: &mut Runtime) {
+    unimplemented!()
+}
+

--- a/imag-store/src/main.rs
+++ b/imag-store/src/main.rs
@@ -47,6 +47,7 @@ use libimagrt::setup::generate_runtime_setup;
 
 mod create;
 mod delete;
+mod dump;
 mod error;
 mod get;
 mod retrieve;
@@ -55,8 +56,11 @@ mod update;
 mod verify;
 mod util;
 
+use std::ops::Deref;
+
 use create::create;
 use delete::delete;
+use dump::dump;
 use get::get;
 use retrieve::retrieve;
 use ui::build_ui;
@@ -69,29 +73,25 @@ fn main() {
                                         "Direct interface to the store. Use with great care!",
                                         build_ui);
 
-    rt.cli()
-        .subcommand_name()
-        .map_or_else(
-            || {
-                debug!("No command");
+    let command = rt.cli().subcommand_name().map(String::from);
+
+    if let Some(command) = command {
+        debug!("Call: {}", command);
+        match command.deref() {
+            "create"   => create(&rt),
+            "delete"   => delete(&rt),
+            "get"      => get(&rt),
+            "retrieve" => retrieve(&rt),
+            "update"   => update(&rt),
+            "verify"   => verify(&rt),
+            "dump"     => dump(&mut rt),
+            _ => {
+                debug!("Unknown command");
                 // More error handling
             },
-            |name| {
-                debug!("Call: {}", name);
-                match name {
-                    "create"   => create(&rt),
-                    "delete"   => delete(&rt),
-                    "get"      => get(&rt),
-                    "retrieve" => retrieve(&rt),
-                    "update"   => update(&rt),
-                    "verify"   => verify(&rt),
-                    "dump"     => dump(&mut rt),
-                    _ => {
-                        debug!("Unknown command");
-                        // More error handling
-                    },
-                };
-            }
-        )
+        };
+    } else {
+        debug!("No command");
+    }
 }
 

--- a/imag-store/src/main.rs
+++ b/imag-store/src/main.rs
@@ -64,10 +64,10 @@ use update::update;
 use verify::verify;
 
 fn main() {
-    let rt = generate_runtime_setup("imag-store",
-                                    &version!()[..],
-                                    "Direct interface to the store. Use with great care!",
-                                    build_ui);
+    let mut rt = generate_runtime_setup("imag-store",
+                                        &version!()[..],
+                                        "Direct interface to the store. Use with great care!",
+                                        build_ui);
 
     rt.cli()
         .subcommand_name()
@@ -85,6 +85,7 @@ fn main() {
                     "retrieve" => retrieve(&rt),
                     "update"   => update(&rt),
                     "verify"   => verify(&rt),
+                    "dump"     => dump(&mut rt),
                     _ => {
                         debug!("Unknown command");
                         // More error handling

--- a/imag-store/src/ui.rs
+++ b/imag-store/src/ui.rs
@@ -205,4 +205,9 @@ pub fn build_ui<'a>(app: App<'a, 'a>) -> App<'a, 'a> {
                    .about("Verify the store")
                    .version("0.1")
                    )
+
+       .subcommand(SubCommand::with_name("dump")
+                   .about("Dump the complete store to stdout. Currently does only support JSON")
+                   .version("0.1")
+                   )
 }


### PR DESCRIPTION
This uses the new backend-replacing mechanism to dump the store to stdout.

It does currently not work as expected.

To reproduce:

```bash
../target/debug/imag-store --config ../imagrc.toml --override-config store.implicit-create=true --rtp /tmp/ dump
```

Outputs:

```
Config file parser error:
ERROR[   1]: a custom error
[imag][WARN]: No config file found.
[imag][WARN]: Continuing without configuration file

ERROR[   1]: StoreId 'id' part is absolute (starts with '/') which is not allowed

ERROR[   1]: StoreId 'id' part is absolute (starts with '/') which is not allowed
{"version":"0.3.0","store":{}}
ERROR[   1]: JSON error
ERROR[   2]: IO Error -- caused:
ERROR[   3]: Could not instantiate
[imag][ERROR]: Loading Store IO backend failed
```

So the store gets actually dumped to stdout as expected, though the errors (and the exit code) are not as expected.

@mario-kr You are always enthusiastic in debugging such things - do you care? :smile: 