### PR TITLE
Fix: Re-set file length before writing to it

### DIFF
--- a/libimagstore/src/file_abstraction/fs.rs
+++ b/libimagstore/src/file_abstraction/fs.rs
@@ -84,6 +84,9 @@ impl FileAbstractionInstance for FSFileAbstractionInstance {
                 // access to the file to be in a different context
                 try!(f.seek(SeekFrom::Start(0))
                     .map_err_into(SEK::FileNotCreated));
+
+                try!(f.set_len(buf.len() as u64).map_err_into(SEK::FileNotWritten));
+
                 f.write_all(&buf).map_err_into(SEK::FileNotWritten)
             },
             FSFileAbstractionInstance::Absent(ref p) =>


### PR DESCRIPTION
This fixes a nasty bug when removing content from files, where remaining things were in the file after writing to it.