### PR TITLE
Export store-consistency-check from libimagentrylink in UI

### DIFF
--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -84,9 +84,23 @@ fn main() {
 }
 
 fn handle_internal_linking(rt: &Runtime) {
+    use libimagentrylink::internal::store_check::StoreLinkConsistentExt;
 
     debug!("Handle internal linking call");
     let cmd = rt.cli().subcommand_matches("internal").unwrap();
+
+    if cmd.is_present("check-consistency") {
+        match rt.store().check_link_consistency() {
+            Ok(_) => {
+                info!("Store is consistent");
+                return;
+            }
+            Err(e) => {
+                trace_error(&e);
+                ::std::process::exit(1);
+            }
+        }
+    }
 
     match cmd.value_of("list") {
         Some(list) => handle_internal_linking_list_call(rt, cmd, list),

--- a/imag-link/src/ui.rs
+++ b/imag-link/src/ui.rs
@@ -78,6 +78,13 @@ pub fn build_ui<'a>(app: App<'a, 'a>) -> App<'a, 'a> {
                          .takes_value(false)
                          .required(false)
                          .help("If --list is provided, also list external links (debugging helper that might be removed at some point"))
+
+                    .arg(Arg::with_name("check-consistency")
+                         .long("check-consistency")
+                         .short("C")
+                         .takes_value(false)
+                         .required(false)
+                         .help("Check the link-consistency in the store (might be time-consuming)"))
                     )
         .subcommand(SubCommand::with_name("external")
                     .about("Add and remove external links")


### PR DESCRIPTION
Closes #964 

The link-consistency-check does report "OK" even when the links are inconsistent.

Filed in #990
