### PR TITLE
Update to rustc 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rust:
 
 matrix:
   include:
-    - rust: 1.15.0
+    - rust: 1.17.0
   allow_failures:
     - rust: nightly
 


### PR DESCRIPTION
As the dependency

    unicode-bidi

requires rustc 1.17 as minimum version of the rust compiler, we have to
update as well.