### PR TITLE
Move utility functionality for tests into libimagutil

### DIFF
--- a/imag-link/Cargo.toml
+++ b/imag-link/Cargo.toml
@@ -37,3 +37,8 @@ path = "../libimagerror"
 [dependencies.libimagutil]
 path = "../libimagutil"
 
+[dev-dependencies.libimagutil]
+path = "../libimagutil"
+default-features = false
+features         = ["testing"]
+

--- a/libimagutil/Cargo.toml
+++ b/libimagutil/Cargo.toml
@@ -13,6 +13,12 @@ documentation = "https://matthiasbeyer.github.io/imag/imag_documentation/index.h
 repository    = "https://github.com/matthiasbeyer/imag"
 homepage      = "http://imag-pim.org"
 
+[features]
+default = []
+
+# Testing feature to compile testing utilities into the library.
+testing = []
+
 [dependencies]
 url = "1.2"
 boolinator = "2.4.0"

--- a/libimagutil/src/lib.rs
+++ b/libimagutil/src/lib.rs
@@ -49,3 +49,7 @@ pub mod key_value_split;
 pub mod variants;
 pub mod warn_exit;
 pub mod warn_result;
+
+#[cfg(feature = "testing")]
+pub mod testing;
+

--- a/libimagutil/src/testing.rs
+++ b/libimagutil/src/testing.rs
@@ -1,0 +1,115 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+pub static DEFAULT_ENTRY: &'static str = "\
+---\
+[imag]\
+links = []\
+version = \"0.3.0\"\
+---";
+
+/// Generator helper macro for mock app (for testing only)
+///
+/// Requires the following crates in scope:
+///
+/// * std
+/// * libimagrt
+/// * clap
+///
+#[macro_export]
+macro_rules! make_mock_app {
+    {
+        app $appname:expr;
+        module $module:ident;
+        version $version:expr;
+    } => {
+        make_mock_app! {
+            app $appname;
+            module $module;
+            version $version;
+            with help "This is a mocking app";
+        }
+    };
+
+    {
+        app $appname:expr;
+        modulename $module:ident;
+        version $version:expr;
+        with help $help:expr;
+    }=> {
+        mod $module {
+            use clap::{App, ArgMatches};
+            use libimagrt::spec::CliSpec;
+            use libimagrt::runtime::Runtime;
+            use libimagrt::error::RuntimeError;
+            use libimagrt::configuration::{Configuration, InternalConfiguration};
+
+            #[derive(Clone)]
+            struct MockLinkApp<'a> {
+                args: Vec<&'static str>,
+                inner: App<'a, 'a>,
+            }
+
+            impl<'a> MockLinkApp<'a> {
+                fn new(args: Vec<&'static str>) -> Self {
+                    MockLinkApp {
+                        args: args,
+                        inner: ::build_ui(Runtime::get_default_cli_builder($appname, $version, $help)),
+                    }
+                }
+            }
+
+            impl<'a> CliSpec<'a> for MockLinkApp<'a> {
+                fn name(&self) -> &str {
+                    self.inner.get_name()
+                }
+
+                fn matches(self) -> ArgMatches<'a> {
+                    self.inner.get_matches_from(self.args)
+                }
+            }
+
+            impl<'a> InternalConfiguration for MockLinkApp<'a> {
+                fn enable_logging(&self) -> bool {
+                    false
+                }
+
+                fn use_inmemory_fs(&self) -> bool {
+                    true
+                }
+            }
+
+            pub fn generate_minimal_test_config() -> Option<Configuration> { ::toml::de::from_str("[store]\nimplicit-create=true")
+                            .map(Configuration::with_value)
+                            .ok()
+            }
+
+            pub fn generate_test_runtime<'a>(mut args: Vec<&'static str>) -> Result<Runtime<'a>, RuntimeError> {
+                let mut cli_args = vec!["imag-link", "--rtp", "/tmp"];
+
+                cli_args.append(&mut args);
+
+                let cli_app = MockLinkApp::new(cli_args);
+                Runtime::with_configuration(cli_app, generate_minimal_test_config())
+            }
+        }
+    };
+
+}
+


### PR DESCRIPTION
:tada: This is Issue/Pr no. 1000. Holy cow! :tada: 

This moves the testing functionality for CLI testing to the libimagutil (behind a feature gate, of course).