### PR TITLE
Update version strings for next release: 0.3.0 -> 0.4.0

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag command"

--- a/doc/src/00000.md
+++ b/doc/src/00000.md
@@ -1,6 +1,6 @@
 ---
 title: imag User Documentation
-version: 0.3.0
+version: 0.4.0
 date: August 2017
 listings: true
 codeBlockCaptions: true

--- a/doc/src/02000-store.md
+++ b/doc/src/02000-store.md
@@ -72,7 +72,7 @@ An example for a file in the store follows.
 ---
 [imag]
 links = ["/home/user/more_kittens.mpeg"]
-version = "0.3.0"
+version = "0.4.0"
 
 [note]
 name = "foo"
@@ -257,12 +257,12 @@ The strucure is as follows:
 
 ```json
 {
-    "version": "0.3.0",
+    "version": "0.4.0",
     "store": {
         "example": {
             "header": {
                 "imag": {
-                    "version": "0.3.0",
+                    "version": "0.4.0",
                 },
             },
             "content": "hi there!",

--- a/imag-bookmark/Cargo.toml
+++ b/imag-bookmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-bookmark"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-bookmark command"

--- a/imag-counter/Cargo.toml
+++ b/imag-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-counter"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-counter command"

--- a/imag-diary/Cargo.toml
+++ b/imag-diary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-diary"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-diary command"

--- a/imag-link/Cargo.toml
+++ b/imag-link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-link"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-link command"

--- a/imag-link/src/main.rs
+++ b/imag-link/src/main.rs
@@ -356,7 +356,7 @@ mod tests {
     make_mock_app! {
         app "imag-link";
         modulename mock;
-        version "0.3.0";
+        version "0.4.0";
         with help "imag-link mocking app";
     }
     use self::mock::generate_test_runtime;

--- a/imag-mail/Cargo.toml
+++ b/imag-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-mail"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-notes command"

--- a/imag-notes/Cargo.toml
+++ b/imag-notes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-notes"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-notes command"

--- a/imag-ref/Cargo.toml
+++ b/imag-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-ref"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-ref command"

--- a/imag-store/Cargo.toml
+++ b/imag-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-store"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-store command"

--- a/imag-store/tests/001-create_test.sh
+++ b/imag-store/tests/001-create_test.sh
@@ -42,7 +42,7 @@ test_std_header() {
 ---
 [imag]
 links = []
-version = "0.3.0"
+version = "0.4.0"
 ---
 
 EOS
@@ -63,7 +63,7 @@ test_std_header_plus_custom() {
 ---
 [imag]
 links = []
-version = "0.3.0"
+version = "0.4.0"
 
 [zzz]
 zzz = "z"
@@ -90,7 +90,7 @@ bar = "baz"
 
 [imag]
 links = []
-version = "0.3.0"
+version = "0.4.0"
 
 [zzz]
 zzz = "z"
@@ -116,7 +116,7 @@ test_std_header_plus_custom_multiheader_same_section() {
 ---
 [imag]
 links = []
-version = "0.3.0"
+version = "0.4.0"
 
 [zzz]
 bar = "baz"
@@ -142,7 +142,7 @@ test_std_header_plus_custom_and_content() {
 ---
 [imag]
 links = []
-version = "0.3.0"
+version = "0.4.0"
 
 [zzz]
 zzz = "z"

--- a/imag-store/tests/002-retrieve_test.sh
+++ b/imag-store/tests/002-retrieve_test.sh
@@ -8,7 +8,7 @@ std_header() {
 ---
 [imag]
 links = []
-version = "0.3.0"
+version = "0.4.0"
 ---
 EOS
 }

--- a/imag-tag/Cargo.toml
+++ b/imag-tag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-tag"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-tag command"

--- a/imag-tag/src/main.rs
+++ b/imag-tag/src/main.rs
@@ -196,7 +196,7 @@ mod tests {
     make_mock_app! {
         app "imag-tag";
         modulename mock;
-        version "0.3.0";
+        version "0.4.0";
         with help "imag-tag mocking app";
     }
     use self::mock::generate_test_runtime;

--- a/imag-timetrack/Cargo.toml
+++ b/imag-timetrack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-timetrack"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-tag command"

--- a/imag-todo/Cargo.toml
+++ b/imag-todo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["mario <mario-krehl@gmx.de>"]
 name = "imag-todo"
-version = "0.3.0"
+version = "0.4.0"
 
 description = "Part of the imag core distribution: imag-todo command"
 

--- a/imag-view/Cargo.toml
+++ b/imag-view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imag-view"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Part of the imag core distribution: imag-view command"

--- a/libimagannotation/Cargo.toml
+++ b/libimagannotation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagannotation"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagbookmark/Cargo.toml
+++ b/libimagbookmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagbookmark"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagcounter/Cargo.toml
+++ b/libimagcounter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagcounter"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagdiary/Cargo.toml
+++ b/libimagdiary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagdiary"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrycategory/Cargo.toml
+++ b/libimagentrycategory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrycategory"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrydatetime/Cargo.toml
+++ b/libimagentrydatetime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrydatetime"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentryedit/Cargo.toml
+++ b/libimagentryedit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentryedit"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentryfilter/Cargo.toml
+++ b/libimagentryfilter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentryfilter"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrylink/Cargo.toml
+++ b/libimagentrylink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrylink"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrylist/Cargo.toml
+++ b/libimagentrylist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrylist"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrymarkdown/Cargo.toml
+++ b/libimagentrymarkdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrymarkdown"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrytag/Cargo.toml
+++ b/libimagentrytag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrytag"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentrytimetrack/Cargo.toml
+++ b/libimagentrytimetrack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentrytimetrack"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagentryview/Cargo.toml
+++ b/libimagentryview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagentryview"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagerror/Cargo.toml
+++ b/libimagerror/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagerror"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimaginteraction/Cargo.toml
+++ b/libimaginteraction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimaginteraction"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagmail/Cargo.toml
+++ b/libimagmail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagmail"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagnotes/Cargo.toml
+++ b/libimagnotes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagnotes"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagref/Cargo.toml
+++ b/libimagref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagref"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagrt/Cargo.toml
+++ b/libimagrt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagrt"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagstore/Cargo.toml
+++ b/libimagstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagstore"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagstore/src/file_abstraction/mod.rs
+++ b/libimagstore/src/file_abstraction/mod.rs
@@ -107,7 +107,7 @@ mod test {
         let loca = StoreId::new_baseless(path).unwrap();
         let file = Entry::from_str(loca.clone(), r#"---
 [imag]
-version = "0.3.0"
+version = "0.4.0"
 ---
 Hello World"#).unwrap();
 

--- a/libimagstore/src/file_abstraction/stdio/mapper/json.rs
+++ b/libimagstore/src/file_abstraction/stdio/mapper/json.rs
@@ -165,7 +165,7 @@ mod test {
 
     #[test]
     fn test_empty_json_to_fs() {
-        let json = r#"{"version":"0.3.0","store":{}}"#;
+        let json = r#"{"version":"0.4.0","store":{}}"#;
         let mut json = Cursor::new(String::from(json).into_bytes());
         let mapper   = JsonMapper::new();
         let mut hm   = HashMap::new();
@@ -178,12 +178,12 @@ mod test {
     #[test]
     fn test_json_to_fs() {
         let json = r#"
-        { "version": "0.3.0",
+        { "version": "0.4.0",
           "store": {
             "example": {
                 "header": {
                     "imag": {
-                        "version": "0.3.0"
+                        "version": "0.4.0"
                     }
                 },
                 "content": "test"
@@ -210,7 +210,7 @@ mod test {
             let mut hm = HashMap::new();
             let content = r#"---
 [imag]
-version = "0.3.0"
+version = "0.4.0"
 ---
 hi there!"#;
 
@@ -225,12 +225,12 @@ hi there!"#;
 
         let example = r#"
         {
-            "version": "0.3.0",
+            "version": "0.4.0",
             "store": {
                 "example": {
                     "header": {
                         "imag": {
-                            "version": "0.3.0"
+                            "version": "0.4.0"
                         }
                     },
                     "content": "hi there!"

--- a/libimagstore/src/store.rs
+++ b/libimagstore/src/store.rs
@@ -1325,7 +1325,7 @@ mod store_tests {
 
                 // Lets have an empty store as input
                 let mut input = Cursor::new(r#"
-                { "version": "0.3.0",
+                { "version": "0.4.0",
                     "store": { }
                 }
                 "#);
@@ -1362,7 +1362,7 @@ mod store_tests {
             Value::Object(ref map) => {
                 assert!(map.get("version").is_some(), format!("No 'version' in JSON"));
                 match map.get("version").unwrap() {
-                    &Value::String(ref s) => assert_eq!("0.3.0", s),
+                    &Value::String(ref s) => assert_eq!("0.4.0", s),
                     _ => panic!("Wrong type in JSON at 'version'"),
                 }
 
@@ -1663,12 +1663,12 @@ mod store_tests {
 
                 // Lets have an empty store as input
                 let mut input = Cursor::new(r#"
-                { "version": "0.3.0",
+                { "version": "0.4.0",
                     "store": {
                         "example": {
                             "header": {
                                 "imag": {
-                                    "version": "0.3.0"
+                                    "version": "0.4.0"
                                 }
                             },
                             "content": "foobar"
@@ -1712,7 +1712,7 @@ mod store_tests {
             Value::Object(ref map) => {
                 assert!(map.get("version").is_some(), format!("No 'version' in JSON"));
                 match map.get("version").unwrap() {
-                    &Value::String(ref s) => assert_eq!("0.3.0", s),
+                    &Value::String(ref s) => assert_eq!("0.4.0", s),
                     _ => panic!("Wrong type in JSON at 'version'"),
                 }
 

--- a/libimagtimeui/Cargo.toml
+++ b/libimagtimeui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagtimeui"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagtodo/Cargo.toml
+++ b/libimagtodo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagtodo"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["mario <mario-krehl@gmx.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagutil/Cargo.toml
+++ b/libimagutil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libimagutil"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library for the imag core distribution"

--- a/libimagutil/src/testing.rs
+++ b/libimagutil/src/testing.rs
@@ -21,7 +21,7 @@ pub static DEFAULT_ENTRY: &'static str = "\
 ---\
 [imag]\
 links = []\
-version = \"0.3.0\"\
+version = \"0.4.0\"\
 ---";
 
 /// Generator helper macro for mock app (for testing only)


### PR DESCRIPTION
Updates the version strings for all imag libraries and binaries to 0.4.0, including in the source (tests and such).