### PR TITLE
Fix warnings by not allowing them anymore

### DIFF
--- a/lib/core/libimagerror/src/lib.rs
+++ b/lib/core/libimagerror/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/core/libimagstore/src/lib.rs
+++ b/lib/core/libimagstore/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/domain/libimagbookmark/src/lib.rs
+++ b/lib/domain/libimagbookmark/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/domain/libimagcounter/src/lib.rs
+++ b/lib/domain/libimagcounter/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/domain/libimagmail/src/lib.rs
+++ b/lib/domain/libimagmail/src/lib.rs
@@ -17,6 +17,22 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate log;
 extern crate email;
 extern crate semver;

--- a/lib/domain/libimagmail/src/mail.rs
+++ b/lib/domain/libimagmail/src/mail.rs
@@ -53,6 +53,7 @@ impl<'a> Mail<'a> {
 
     /// Imports a mail from the Path passed
     pub fn import_from_path<P: AsRef<Path>>(store: &Store, p: P) -> Result<Mail> {
+        debug!("Importing Mail from path");
         let h = MailHasher::new();
         let f = RefFlags::default().with_content_hashing(true).with_permission_tracking(false);
         let p = PathBuf::from(p.as_ref());
@@ -60,6 +61,7 @@ impl<'a> Mail<'a> {
         Ref::create_with_hasher(store, p, f, h)
             .map_err_into(MEK::RefCreationError)
             .and_then(|reference| {
+                debug!("Build reference file: {:?}", reference);
                 reference.fs_file()
                     .map_err_into(MEK::RefHandlingError)
                     .and_then(|path| File::open(path).map_err_into(MEK::IOError))
@@ -76,6 +78,7 @@ impl<'a> Mail<'a> {
 
     /// Opens a mail by the passed hash
     pub fn open<S: AsRef<str>>(store: &Store, hash: S) -> Result<Option<Mail>> {
+        debug!("Opening Mail by Hash");
         Ref::get_by_hash(store, String::from(hash.as_ref()))
             .map_err_into(MEK::FetchByHashError)
             .map_err_into(MEK::FetchError)
@@ -88,6 +91,7 @@ impl<'a> Mail<'a> {
 
     /// Implement me as TryFrom as soon as it is stable
     pub fn from_ref(r: Ref<'a>) -> Result<Mail> {
+        debug!("Building Mail object from Ref: {:?}", r);
         r.fs_file()
             .map_err_into(MEK::RefHandlingError)
             .and_then(|path| File::open(path).map_err_into(MEK::IOError))
@@ -102,6 +106,7 @@ impl<'a> Mail<'a> {
     }
 
     pub fn get_field(&self, field: &str) -> Result<Option<String>> {
+        debug!("Getting field in mail: {:?}", field);
         self.1
             .parsed()
             .map_err_into(MEK::MailParsingError)

--- a/lib/domain/libimagtimetrack/src/iter/filter.rs
+++ b/lib/domain/libimagtimetrack/src/iter/filter.rs
@@ -17,10 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-use result::Result;
-
 use chrono::NaiveDateTime;
-use filters::filter::Filter;
 
 use libimagstore::store::FileLockEntry;
 

--- a/lib/domain/libimagtimetrack/src/iter/mod.rs
+++ b/lib/domain/libimagtimetrack/src/iter/mod.rs
@@ -30,10 +30,7 @@ mod test {
 
     use libimagstore::store::Store;
 
-    use super::create::*;
-    use super::get::*;
     use super::setendtime::*;
-    use super::storeid::*;
     use super::tag::*;
 
     fn get_store() -> Store {
@@ -53,7 +50,7 @@ mod test {
 
         let iter = tags.into_iter().map(String::from);
 
-        let iter : SetEndTimeIter = TagIter::new(Box::new(iter))
+        let _ : SetEndTimeIter = TagIter::new(Box::new(iter))
             .create_storeids(now)
             .create_entries(&store)
             .set_end_time(then);

--- a/lib/domain/libimagtimetrack/src/lib.rs
+++ b/lib/domain/libimagtimetrack/src/lib.rs
@@ -17,6 +17,22 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 extern crate filters;
 extern crate chrono;
 extern crate toml;

--- a/lib/domain/libimagtodo/src/error.rs
+++ b/lib/domain/libimagtodo/src/error.rs
@@ -22,7 +22,8 @@ generate_error_module!(
         ConversionError     => "Conversion Error",
         StoreError          => "Store Error",
         StoreIdError        => "Store Id handling error",
-        ImportError         => "Error importing"
+        ImportError         => "Error importing",
+        UTF8Error           => "Encountered non-UTF8 characters while reading input"
     );
 );
 

--- a/lib/domain/libimagtodo/src/lib.rs
+++ b/lib/domain/libimagtodo/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/domain/libimagtodo/src/task.rs
+++ b/lib/domain/libimagtodo/src/task.rs
@@ -48,7 +48,7 @@ impl<'a> Task<'a> {
 
     pub fn import<R: BufRead>(store: &'a Store, mut r: R) -> Result<(Task<'a>, String, Uuid)> {
         let mut line = String::new();
-        r.read_line(&mut line);
+        try!(r.read_line(&mut line).map_err_into(TEK::UTF8Error));
         import_task(&line.as_str())
             .map_err_into(TEK::ImportError)
             .and_then(|t| {
@@ -70,7 +70,7 @@ impl<'a> Task<'a> {
         where R: BufRead
     {
         let mut line = String::new();
-        r.read_line(&mut line);
+        try!(r.read_line(&mut line).map_err_into(TEK::UTF8Error));
         Task::get_from_string(store, line)
     }
 
@@ -104,7 +104,7 @@ impl<'a> Task<'a> {
     /// implicitely create the task if it does not exist.
     pub fn retrieve_from_import<R: BufRead>(store: &'a Store, mut r: R) -> Result<Task<'a>> {
         let mut line = String::new();
-        r.read_line(&mut line);
+        try!(r.read_line(&mut line).map_err_into(TEK::UTF8Error));
         Task::retrieve_from_string(store, line)
     }
 

--- a/lib/entry/libimagentryannotation/src/lib.rs
+++ b/lib/entry/libimagentryannotation/src/lib.rs
@@ -37,7 +37,7 @@ extern crate uuid;
 extern crate toml;
 
 #[macro_use] extern crate libimagerror;
-#[macro_use] extern crate libimagstore;
+extern crate libimagstore;
 extern crate libimagentrylink;
 extern crate libimagnotes;
 extern crate libimagutil;

--- a/lib/entry/libimagentryannotation/src/lib.rs
+++ b/lib/entry/libimagentryannotation/src/lib.rs
@@ -17,6 +17,22 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 extern crate uuid;
 extern crate toml;
 

--- a/lib/entry/libimagentrycategory/src/lib.rs
+++ b/lib/entry/libimagentrycategory/src/lib.rs
@@ -17,6 +17,22 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 extern crate toml_query;
 extern crate toml;
 #[macro_use]

--- a/lib/entry/libimagentrydatetime/Cargo.toml
+++ b/lib/entry/libimagentrydatetime/Cargo.toml
@@ -23,6 +23,3 @@ libimagerror = { version = "0.4.0", path = "../../../lib/core/libimagerror" }
 libimagstore = { version = "0.4.0", path = "../../../lib/core/libimagstore" }
 libimagutil  = { version = "0.4.0", path = "../../../lib/etc/libimagutil" }
 
-[dev-dependencies]
-is-match = "0.1"
-

--- a/lib/entry/libimagentrydatetime/src/lib.rs
+++ b/lib/entry/libimagentrydatetime/src/lib.rs
@@ -42,9 +42,6 @@ extern crate toml;
 extern crate libimagstore;
 extern crate libimagutil;
 
-#[cfg(test)]
-#[macro_use] extern crate is_match;
-
 pub mod datepath;
 pub mod datetime;
 pub mod error;

--- a/lib/entry/libimagentrydatetime/src/lib.rs
+++ b/lib/entry/libimagentrydatetime/src/lib.rs
@@ -17,6 +17,22 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate lazy_static;
 extern crate chrono;
 extern crate toml_query;

--- a/lib/entry/libimagentryedit/src/lib.rs
+++ b/lib/entry/libimagentryedit/src/lib.rs
@@ -17,6 +17,22 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+#![deny(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
 #[macro_use] extern crate libimagerror;
 extern crate libimagstore;
 extern crate libimagrt;

--- a/lib/entry/libimagentryfilter/src/lib.rs
+++ b/lib/entry/libimagentryfilter/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,

--- a/lib/entry/libimagentrylink/src/lib.rs
+++ b/lib/entry/libimagentrylink/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/entry/libimagentrymarkdown/src/lib.rs
+++ b/lib/entry/libimagentrymarkdown/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/entry/libimagentryref/src/lib.rs
+++ b/lib/entry/libimagentryref/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/entry/libimagentrytag/src/lib.rs
+++ b/lib/entry/libimagentrytag/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/etc/libimaginteraction/src/lib.rs
+++ b/lib/etc/libimaginteraction/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/etc/libimagtimeui/src/lib.rs
+++ b/lib/etc/libimagtimeui/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,
@@ -26,6 +27,7 @@
     unused_allocation,
     unused_import_braces,
     unused_imports,
+    unused_must_use,
     unused_mut,
     unused_qualifications,
     while_true,

--- a/lib/etc/libimagutil/src/lib.rs
+++ b/lib/etc/libimagutil/src/lib.rs
@@ -18,6 +18,7 @@
 //
 
 #![deny(
+    dead_code,
     non_camel_case_types,
     non_snake_case,
     path_statements,


### PR DESCRIPTION
This might get a bit lengthy. In this first patch, we deny all warnings, hopefully getting to a point where a whole imag build can be done with not one warning.

Patches for fixing the (now) compile errors will follow, feel free to contribute!