### PR TITLE
Add store extraction to Runtime

### DIFF
--- a/bin/core/imag-tag/Cargo.toml
+++ b/bin/core/imag-tag/Cargo.toml
@@ -35,3 +35,9 @@ path             = "../../../lib/etc/libimagutil"
 default-features = false
 features         = ["testing"]
 
+[dev-dependencies.libimagrt]
+version          = "0.4.0"
+path             = "../../../lib/core/libimagrt"
+default-features = false
+features         = ["testing"]
+

--- a/lib/core/libimagrt/Cargo.toml
+++ b/lib/core/libimagrt/Cargo.toml
@@ -27,3 +27,11 @@ toml-query = "0.3.0"
 libimagstore = { version = "0.4.0", path = "../../../lib/core/libimagstore" }
 libimagerror = { version = "0.4.0", path = "../../../lib/core/libimagerror" }
 libimagutil  = { version = "0.4.0", path = "../../../lib/etc/libimagutil" }
+
+[features]
+default = []
+
+# Enable testing functionality. Used for building the libimagrt for testing CLI
+# apps. Do not use in production!
+testing = []
+

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -315,6 +315,29 @@ impl<'a> Runtime<'a> {
         "generate-completion"
     }
 
+    /// Extract the Store object from the Runtime object, destroying the Runtime object
+    ///
+    /// # Warning
+    ///
+    /// This function is for testing _only_! It can be used to re-build a Runtime object with an
+    /// alternative Store.
+    #[cfg(feature = "testing")]
+    pub fn extract_store(self) -> Store {
+        self.store
+    }
+
+    /// Re-set the Store object within
+    ///
+    /// # Warning
+    ///
+    /// This function is for testing _only_! It can be used to re-build a Runtime object with an
+    /// alternative Store.
+    #[cfg(feature = "testing")]
+    pub fn with_store(mut self, s: Store) -> Self {
+        self.store = s;
+        self
+    }
+
     /// Initialize the internal logger
     fn init_logger(is_debugging: bool, is_verbose: bool, colored: bool) {
         use std::env::var as env_var;

--- a/lib/etc/libimagutil/src/testing.rs
+++ b/lib/etc/libimagutil/src/testing.rs
@@ -108,6 +108,18 @@ macro_rules! make_mock_app {
                 let cli_app = MockLinkApp::new(cli_args);
                 Runtime::with_configuration(cli_app, generate_minimal_test_config())
             }
+
+            pub fn reset_test_runtime<'a>(mut args: Vec<&'static str>, old_runtime: Runtime)
+                -> Result<Runtime<'a>, RuntimeError>
+            {
+                let mut cli_args = vec![$appname, "--rtp", "/tmp"];
+
+                cli_args.append(&mut args);
+
+                let cli_app = MockLinkApp::new(cli_args);
+                Runtime::with_configuration(cli_app, generate_minimal_test_config())
+                    .map(|rt| rt.with_store(old_runtime.extract_store()))
+            }
         }
     };
 


### PR DESCRIPTION
This is necessary to be able to re-build a Runtime object with an new
set of "commandline arguments". For example if a test wants to test two
calls to imag, for example a "add" operation followed by a "remove" operation.

These functions are feature-gated therefor and should only be used in
tests.