### PR TITLE
Fix Store loading in tests: Use in-memory store backend

### DIFF
--- a/lib/entry/libimagentrydatetime/src/datetime.rs
+++ b/lib/entry/libimagentrydatetime/src/datetime.rs
@@ -223,7 +223,9 @@ mod tests {
     use chrono::naive::NaiveTime;
 
     pub fn get_store() -> Store {
-        Store::new(PathBuf::from("/"), None).unwrap()
+        use libimagstore::store::InMemoryFileAbstraction;
+        let backend = Box::new(InMemoryFileAbstraction::new());
+        Store::new_with_backend(PathBuf::from("/"), None, backend).unwrap()
     }
 
     #[test]

--- a/lib/entry/libimagentrygps/src/entry.rs
+++ b/lib/entry/libimagentrygps/src/entry.rs
@@ -67,7 +67,9 @@ mod tests {
     }
 
     fn get_store() -> Store {
-        Store::new(PathBuf::from("/"), None).unwrap()
+        use libimagstore::file_abstraction::InMemoryFileAbstraction;
+        let backend = Box::new(InMemoryFileAbstraction::new());
+        Store::new_with_backend(PathBuf::from("/"), None, backend).unwrap()
     }
 
     #[test]

--- a/lib/entry/libimagentrylink/src/internal.rs
+++ b/lib/entry/libimagentrylink/src/internal.rs
@@ -800,7 +800,9 @@ mod test {
     }
 
     pub fn get_store() -> Store {
-        Store::new(PathBuf::from("/"), None).unwrap()
+        use libimagstore::file_abstraction::InMemoryFileAbstraction;
+        let backend = Box::new(InMemoryFileAbstraction::new());
+        Store::new_with_backend(PathBuf::from("/"), None, backend).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
This was able to slip because we did not use `Store::update()` at all, but relied on the `drop()` implementation which calls `Store::_update()`.

It was not that critical, as the tests simply did never hit the FS because of permission denied to create entries at `/`, but it wasn't nice either.