### PR TITLE
Rewrite Store::entries() implementation

### DIFF
--- a/lib/core/libimagstore/src/file_abstraction/inmemory.rs
+++ b/lib/core/libimagstore/src/file_abstraction/inmemory.rs
@@ -32,6 +32,7 @@ use super::FileAbstractionInstance;
 use super::Drain;
 use store::Entry;
 use storeid::StoreId;
+use file_abstraction::iter::PathIterator;
 
 type Backend = Arc<Mutex<RefCell<HashMap<PathBuf, Entry>>>>;
 
@@ -170,6 +171,21 @@ impl FileAbstraction for InMemoryFileAbstraction {
         }
 
         Ok(())
+    }
+
+    fn pathes_recursively(&self, _basepath: PathBuf) -> Result<PathIterator, SE> {
+        debug!("Getting all pathes");
+        let keys : Vec<PathBuf> = self
+            .backend()
+            .lock()
+            .map_err(|_| SE::from_kind(SEK::FileError))?
+            .get_mut()
+            .keys()
+            .map(PathBuf::from)
+            .collect();
+        // we collect here as this happens only in tests and in memory anyways, so no problem
+
+        Ok(PathIterator::new(Box::new(keys.into_iter())))
     }
 }
 

--- a/lib/core/libimagstore/src/file_abstraction/iter.rs
+++ b/lib/core/libimagstore/src/file_abstraction/iter.rs
@@ -1,0 +1,41 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+use std::path::PathBuf;
+
+/// A wrapper for an iterator over `PathBuf`s
+pub struct PathIterator(Box<Iterator<Item = PathBuf>>);
+
+impl PathIterator {
+
+    pub fn new(iter: Box<Iterator<Item = PathBuf>>) -> PathIterator {
+        PathIterator(iter)
+    }
+
+}
+
+impl Iterator for PathIterator {
+    type Item = PathBuf;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+}
+

--- a/lib/core/libimagstore/src/file_abstraction/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/mod.rs
@@ -27,12 +27,14 @@ use storeid::StoreId;
 
 mod fs;
 mod inmemory;
+mod iter;
 pub mod stdio;
 
 pub use self::fs::FSFileAbstraction;
 pub use self::fs::FSFileAbstractionInstance;
 pub use self::inmemory::InMemoryFileAbstraction;
 pub use self::inmemory::InMemoryFileAbstractionInstance;
+use self::iter::PathIterator;
 
 /// An abstraction trait over filesystem actions
 pub trait FileAbstraction : Debug {
@@ -45,6 +47,8 @@ pub trait FileAbstraction : Debug {
 
     fn drain(&self) -> Result<Drain, SE>;
     fn fill<'a>(&'a mut self, d: Drain) -> Result<(), SE>;
+
+    fn pathes_recursively(&self, basepath: PathBuf) -> Result<PathIterator, SE>;
 }
 
 /// An abstraction trait over actions on files

--- a/lib/core/libimagstore/src/file_abstraction/stdio/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/stdio/mod.rs
@@ -36,6 +36,7 @@ use super::FileAbstractionInstance;
 use super::Drain;
 use super::InMemoryFileAbstraction;
 use store::Entry;
+use file_abstraction::iter::PathIterator;
 
 pub mod mapper;
 pub mod out;
@@ -120,6 +121,10 @@ impl<W: Write, M: Mapper> FileAbstraction for StdIoFileAbstraction<W, M> {
 
     fn fill(&mut self, d: Drain) -> Result<(), SE> {
         self.0.fill(d)
+    }
+
+    fn pathes_recursively(&self, basepath: PathBuf) -> Result<PathIterator, SE> {
+        self.0.pathes_recursively(basepath)
     }
 }
 

--- a/lib/core/libimagstore/src/file_abstraction/stdio/out.rs
+++ b/lib/core/libimagstore/src/file_abstraction/stdio/out.rs
@@ -40,6 +40,7 @@ use super::FileAbstractionInstance;
 use super::Drain;
 use super::InMemoryFileAbstraction;
 use store::Entry;
+use file_abstraction::iter::PathIterator;
 
 use super::mapper::Mapper;
 
@@ -149,6 +150,10 @@ impl<W: Write, M: Mapper> FileAbstraction for StdoutFileAbstraction<W, M> {
             backend.insert(path, element);
         }
         Ok(())
+    }
+
+    fn pathes_recursively(&self, basepath: PathBuf) -> Result<PathIterator, SE> {
+        self.mem.pathes_recursively(basepath)
     }
 
 }


### PR DESCRIPTION
As we rely on the filesystem in Store::entries(), which is a bug and
shouldn't be done, we rewrite this function and use the file_abstraction
framework.

Closes #1055 

---

As a sidenote: The implementation is not optimal, though considered good enough right now.