### PR TITLE
libimagentrylink: Fix header locations

### DIFF
--- a/bin/core/imag-link/src/main.rs
+++ b/bin/core/imag-link/src/main.rs
@@ -376,10 +376,10 @@ mod tests {
     }
 
     fn get_entry_links<'a>(entry: &'a FileLockEntry<'a>) -> TomlQueryResult<&'a Value> {
-        match entry.get_header().read(&"imag.links".to_owned()) {
+        match entry.get_header().read(&"links.internal".to_owned()) {
             Err(e) => Err(e),
             Ok(Some(v)) => Ok(v),
-            Ok(None) => panic!("Didn't find 'imag.links' in {:?}", entry),
+            Ok(None) => panic!("Didn't find 'links' in {:?}", entry),
         }
     }
 

--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -34,6 +34,10 @@ This section contains the changelog from the last release to the next release.
 * Fixed bugs
     * The config loading in `libimagrt`
     [was fixed](http://git.imag-pim.org/imag/commit/?id=9193d50f96bce099665d2eb716bcaa29a8d9b8ff).
+    * `libimagentrylink` used `imag` as the location for putting links in
+      entries. This is not allowed because this namespace is reserved for the
+      store itself. This bug was fixed, links are now located in the `links`
+      namespace in the header of an entry.
 * Minor changes
     * If building from a `nix-shell`, the mozilla rust overlay is expected to be
       present

--- a/lib/entry/libimagentrylink/src/internal.rs
+++ b/lib/entry/libimagentrylink/src/internal.rs
@@ -27,7 +27,7 @@ use libimagstore::store::Entry;
 use libimagstore::store::Result as StoreResult;
 
 use toml_query::read::TomlValueReadExt;
-use toml_query::set::TomlValueSetExt;
+use toml_query::insert::TomlValueInsertExt;
 
 use error::LinkErrorKind as LEK;
 use error::LinkError as LE;
@@ -392,7 +392,7 @@ impl InternalLinker for Entry {
     fn get_internal_links(&self) -> Result<LinkIter> {
         let res = self
             .get_header()
-            .read("imag.links")
+            .read("links.internal")
             .chain_err(|| LEK::EntryHeaderReadError)
             .map(|r| r.cloned());
         process_rw_result(res)
@@ -426,7 +426,7 @@ impl InternalLinker for Entry {
                             }));
         let res = self
             .get_header_mut()
-            .set("imag.links", Value::Array(new_links))
+            .insert("links.interal", Value::Array(new_links))
             .chain_err(|| LEK::EntryHeaderReadError);
         process_rw_result(res)
     }
@@ -497,7 +497,7 @@ fn rewrite_links<I: Iterator<Item = Link>>(header: &mut Value, links: I) -> Resu
 
     debug!("Setting new link array: {:?}", links);
     let process = header
-        .set("imag.links", Value::Array(links))
+        .insert("links.internal", Value::Array(links))
         .chain_err(|| LEK::EntryHeaderReadError);
     process_rw_result(process).map(|_| ())
 }
@@ -525,7 +525,7 @@ fn add_foreign_link(target: &mut Entry, from: StoreId) -> Result<()> {
 
             let res = target
                 .get_header_mut()
-                .set("imag.links", Value::Array(links))
+                .insert("links.internal", Value::Array(links))
                 .chain_err(|| LEK::EntryHeaderReadError);
 
             process_rw_result(res).map(|_| ())


### PR DESCRIPTION
The `libimagentrylink` used header fields in the `imag` table, which is reseved for the `libimagstore`. This patch changes the location to `links`.

---

Also change that the implementation uses toml_query::set instead of
toml_query::insert.

Inserting values creates intermediate tables, set doesn't. And we really
want that convenience here, as the code is complex enough on its own.