### PR TITLE
imag-diary: per diary timed config

### DIFF
--- a/bin/domain/imag-diary/Cargo.toml
+++ b/bin/domain/imag-diary/Cargo.toml
@@ -18,6 +18,8 @@ chrono = "0.4"
 version = "2.0"
 clap = "2.*"
 log = "0.3"
+toml = "0.4"
+toml-query = "0.3.1"
 
 libimagerror       = { version = "0.4.0", path = "../../../lib/core/libimagerror" }
 libimagstore       = { version = "0.4.0", path = "../../../lib/core/libimagstore" }

--- a/bin/domain/imag-diary/src/main.rs
+++ b/bin/domain/imag-diary/src/main.rs
@@ -36,6 +36,8 @@
 #[macro_use] extern crate version;
 extern crate clap;
 extern crate chrono;
+extern crate toml;
+extern crate toml_query;
 
 extern crate libimagdiary;
 extern crate libimagentryedit;

--- a/bin/domain/imag-diary/src/util.rs
+++ b/bin/domain/imag-diary/src/util.rs
@@ -18,6 +18,10 @@
 //
 
 use libimagrt::runtime::Runtime;
+use libimagdiary::error::*;
+
+use toml::Value;
+use toml_query::read::TomlValueReadExt;
 
 pub fn get_diary_name(rt: &Runtime) -> Option<String> {
     use libimagdiary::config::get_default_diary_name;
@@ -26,3 +30,56 @@ pub fn get_diary_name(rt: &Runtime) -> Option<String> {
         .or(rt.cli().value_of("diaryname").map(String::from))
 }
 
+pub enum Timed {
+    Hourly,
+    Minutely,
+}
+
+/// Returns true if the diary should always create timed entries, which is whenever
+///
+/// ```toml
+/// diary.diaries.<diary>.timed = true
+/// ```
+///
+/// # Returns
+///
+/// * Ok(Some(Timed::Hourly)) if diary should create timed entries
+/// * Ok(Some(Timed::Minutely)) if diary should not create timed entries
+/// * Ok(None) if config is not available
+/// * Err(e) if reading the toml failed, type error or something like this
+///
+pub fn get_diary_timed_config(rt: &Runtime, diary_name: &str) -> Result<Option<Timed>> {
+    match rt.config() {
+        None      => Ok(None),
+        Some(cfg) => {
+            let v = cfg
+                .config()
+                .read(&format!("diary.diaries.{}.timed", diary_name))
+                .chain_err(|| DiaryErrorKind::IOError);
+
+            match v {
+                Ok(Some(&Value::String(ref s))) => parse_timed_string(s, diary_name).map(Some),
+
+                Ok(Some(_)) => {
+                    let s = format!("Type error at 'diary.diaryies.{}.timed': should be either 'h'/'hourly' or 'm'/'minutely'", diary_name);
+                    Err(s).map_err(From::from)
+                },
+
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+pub fn parse_timed_string(s: &str, diary_name: &str) -> Result<Timed> {
+    if s == "h" || s == "hourly" {
+        Ok(Timed::Hourly)
+    } else if s == "m" || s == "minutely" {
+        Ok(Timed::Minutely)
+    } else {
+        let s = format!("Cannot parse config: 'diary.diaries.{}.timed = {}'",
+                        diary_name, s);
+        Err(s).map_err(From::from)
+    }
+}

--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -29,6 +29,9 @@ This section contains the changelog from the last release to the next release.
     * The error handling of the whole codebase is based on the `error_chain`
       now. `libimagerror` only contains convenience functionality, no
       error-generating macros or such things anymore.
+    * `imag-diary` can now use a configuration in the imagrc.toml file where for
+      each diary there is a config whether entries should be created minutely or
+      hourly (or daily, which is when specifying nothing).
 * New
     * `libimagentrygps` was introduced
 * Fixed bugs

--- a/imagrc.toml
+++ b/imagrc.toml
@@ -76,3 +76,9 @@ readline_prompt = ">> "
 # lives implicitely
 implicit-create = false
 
+[diary]
+default_diary = "default"
+
+[diary.diaries.default]
+timed = "minutely"
+


### PR DESCRIPTION
The config file can be used to set a diary to create timed or non-timed entries.

Compiles and tested. But I would like to test it a bit more before merging, especially whether cli-overrides-config works.