### PR TITLE
Fix: Let the track command parse the start/end time more intelligently

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -53,6 +53,8 @@ This section contains the changelog from the last release to the next release.
     * We compile with rustc 1.17, 1.18, .., nightly
     * The `imag-store` binary now uses positional arguments in its CLI
     * The "toml-query" dependency was updated to 0.3.1
+    * `imag-timetrack track` is now able to parse "now", date-only start/stop
+      dates and date-time start/stop times.
 * Stats
 
 ## 0.3.0


### PR DESCRIPTION
It understands "now" from this point and can parse dates or date-times
(whereas dates get normalized to date + hour 0, minute 0, second 0).