### PR TITLE
imag-grep: Add new crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     ".imag-documentation",
     "bin/core/imag",
+    "bin/core/imag-grep",
     "bin/core/imag-link",
     "bin/core/imag-ref",
     "bin/core/imag-store",

--- a/bin/core/imag-grep/Cargo.toml
+++ b/bin/core/imag-grep/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "imag-grep"
+version = "0.4.0"
+authors = ["Matthias Beyer <mail@beyermatthias.de>"]
+
+description = "Part of the imag core distribution: imag-grep command"
+
+keywords    = ["imag", "PIM", "personal", "information", "management"]
+readme      = "../../../README.md"
+license     = "LGPL-2.1"
+
+documentation = "https://matthiasbeyer.github.io/imag/imag_documentation/index.html"
+repository    = "https://github.com/matthiasbeyer/imag"
+homepage      = "http://imag-pim.org"
+
+[dependencies]
+clap = ">=2.17"
+version = "2.0.1"
+regex = "0.2"
+
+libimagstore     = { version = "0.4.0", path = "../../../lib/core/libimagstore" }
+libimagrt        = { version = "0.4.0", path = "../../../lib/core/libimagrt" }
+libimagerror     = { version = "0.4.0", path = "../../../lib/core/libimagerror" }
+

--- a/bin/core/imag-grep/src/main.rs
+++ b/bin/core/imag-grep/src/main.rs
@@ -1,0 +1,117 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+#![deny(
+    non_camel_case_types,
+    non_snake_case,
+    path_statements,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_allocation,
+    unused_import_braces,
+    unused_imports,
+    unused_must_use,
+    unused_mut,
+    unused_qualifications,
+    while_true,
+)]
+
+extern crate clap;
+extern crate regex;
+#[macro_use] extern crate version;
+
+extern crate libimagstore;
+extern crate libimagrt;
+extern crate libimagerror;
+
+use regex::Regex;
+
+use libimagrt::setup::generate_runtime_setup;
+use libimagstore::iter::get::StoreIdGetIteratorExtension;
+use libimagstore::store::Entry;
+use libimagerror::trace::MapErrTrace;
+
+mod ui;
+
+struct Options {
+    files_with_matches: bool,
+    count: bool,
+}
+
+fn main() {
+    let rt = generate_runtime_setup("imag-grep",
+                                    &version!()[..],
+                                    "grep through entries text",
+                                    ui::build_ui);
+
+    let opts = Options {
+        files_with_matches    : rt.cli().is_present("files-with-matches"),
+        count                 : rt.cli().is_present("count"),
+    };
+
+    let mut count : usize = 0;
+
+    let pattern = rt
+        .cli()
+        .value_of("pattern")
+        .map(Regex::new)
+        .unwrap() // ensured by clap
+        .map_err_trace_exit(1)
+        .unwrap(); // ensured by line above
+
+    let overall_count = rt
+        .store()
+        .entries()
+        .map_err_trace_exit(1)
+        .unwrap() // ensured by above line
+        .into_get_iter(rt.store())
+        .filter_map(|res| res.map_err_trace_exit(1).unwrap())
+        .filter(|entry| pattern.is_match(entry.get_content()))
+        .map(|entry| show(&entry, &pattern, &opts, &mut count))
+        .count();
+
+    if opts.count {
+        println!("{}", count);
+    } else {
+        println!("Processed {} files, {} matches, {} nonmatches",
+                 overall_count,
+                 count,
+                 overall_count - count);
+    }
+}
+
+fn show(e: &Entry, re: &Regex, opts: &Options, count: &mut usize) {
+    if opts.files_with_matches {
+        println!("{}", e.get_location());
+    } else if opts.count {
+        *count += 1;
+    } else {
+        println!("{}:", e.get_location());
+        for capture in re.captures_iter(e.get_content()) {
+            for mtch in capture.iter() {
+                if let Some(m) = mtch {
+                    println!(" '{}'", m.as_str());
+                }
+            }
+        }
+
+        println!("");
+    }
+}
+

--- a/bin/core/imag-grep/src/ui.rs
+++ b/bin/core/imag-grep/src/ui.rs
@@ -1,0 +1,47 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+use clap::{Arg, App};
+
+pub fn build_ui<'a>(app: App<'a, 'a>) -> App<'a, 'a> {
+    app
+        .arg(Arg::with_name("files-with-matches")
+             .long("files-with-matches")
+             .short("l")
+             .takes_value(false)
+             .required(false)
+             .multiple(false)
+             .help("List files with matches"))
+
+        .arg(Arg::with_name("count")
+             .long("count")
+             .short("c")
+             .takes_value(false)
+             .required(false)
+             .multiple(false)
+             .help("Count matches"))
+
+        .arg(Arg::with_name("pattern")
+             .index(1)
+             .takes_value(false)
+             .required(true)
+             .multiple(false)
+             .value_name("PATTERN")
+             .help("Pattern to search for. Regex is supported, multiple patterns are not."))
+}

--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -34,6 +34,7 @@ This section contains the changelog from the last release to the next release.
       hourly (or daily, which is when specifying nothing).
 * New
     * `libimagentrygps` was introduced
+    * `imag-grep` was introduced
 * Fixed bugs
     * The config loading in `libimagrt`
     [was fixed](http://git.imag-pim.org/imag/commit/?id=9193d50f96bce099665d2eb716bcaa29a8d9b8ff).


### PR DESCRIPTION
A fairly simple crate, but nonetheless nice.

This crate could be a very good example on how to write imag commands, as a lot of features of the imag codebase are shown, such as iterator chaining, error handling and such.