### PR TITLE
Testing default entry fix

### DIFF
--- a/bin/core/imag-link/src/main.rs
+++ b/bin/core/imag-link/src/main.rs
@@ -352,7 +352,7 @@ mod tests {
 
     use libimagrt::runtime::Runtime;
     use libimagstore::storeid::StoreId;
-    use libimagstore::store::{Result as StoreResult, FileLockEntry};
+    use libimagstore::store::{Result as StoreResult, FileLockEntry, Entry};
 
     make_mock_app! {
         app "imag-link";
@@ -362,15 +362,16 @@ mod tests {
     }
     use self::mock::generate_test_runtime;
     use self::mock::reset_test_runtime;
-    use libimagutil::testing::DEFAULT_ENTRY;
 
     fn create_test_default_entry<'a, S: AsRef<OsStr>>(rt: &'a Runtime, name: S) -> StoreResult<StoreId> {
         let mut path = PathBuf::new();
         path.set_file_name(name);
 
+        let default_entry = Entry::new(StoreId::new_baseless(PathBuf::from("")).unwrap()).to_str();
+
         let id = StoreId::new_baseless(path)?;
         let mut entry = rt.store().create(id.clone())?;
-        entry.get_content_mut().push_str(DEFAULT_ENTRY);
+        entry.get_content_mut().push_str(&default_entry);
 
         Ok(id)
     }

--- a/bin/core/imag-tag/src/main.rs
+++ b/bin/core/imag-tag/src/main.rs
@@ -229,7 +229,7 @@ mod tests {
 
     use libimagrt::runtime::Runtime;
     use libimagstore::storeid::StoreId;
-    use libimagstore::store::{Result as StoreResult, FileLockEntry};
+    use libimagstore::store::{Result as StoreResult, FileLockEntry, Entry};
 
     use super::*;
 
@@ -240,15 +240,16 @@ mod tests {
         with help "imag-tag mocking app";
     }
     use self::mock::generate_test_runtime;
-    use libimagutil::testing::DEFAULT_ENTRY;
 
     fn create_test_default_entry<'a, S: AsRef<OsStr>>(rt: &'a Runtime, name: S) -> StoreResult<StoreId> {
         let mut path = PathBuf::new();
         path.set_file_name(name);
 
+        let default_entry = Entry::new(StoreId::new_baseless(PathBuf::from("")).unwrap()).to_str();
+
         let id = StoreId::new_baseless(path)?;
         let mut entry = rt.store().create(id.clone())?;
-        entry.get_content_mut().push_str(DEFAULT_ENTRY);
+        entry.get_content_mut().push_str(&default_entry);
 
         Ok(id)
     }

--- a/lib/etc/libimagutil/src/testing.rs
+++ b/lib/etc/libimagutil/src/testing.rs
@@ -17,13 +17,6 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-pub static DEFAULT_ENTRY: &'static str = "\
----\
-[imag]\
-links = []\
-version = \"0.4.0\"\
----";
-
 /// Generator helper macro for mock app (for testing only)
 ///
 /// Requires the following crates in scope:


### PR DESCRIPTION
We should not rely on a string which looks like a default entry, but simply create an empty entry and parse it to a string.