### PR TITLE
libimagentrygps: More functionality

### DIFF
--- a/lib/entry/libimagentrygps/src/types.rs
+++ b/lib/entry/libimagentrygps/src/types.rs
@@ -49,6 +49,19 @@ impl GPSValue {
             seconds: s
         }
     }
+
+    pub fn degree(&self) -> i8 {
+        self.degree
+    }
+
+    pub fn minutes(&self) -> i8 {
+        self.minutes
+    }
+
+    pub fn seconds(&self) -> i8 {
+        self.seconds
+    }
+
 }
 
 
@@ -118,6 +131,14 @@ impl Coordinates {
             longitude: long,
             latitude:  lat,
         }
+    }
+
+    pub fn longitude(&self) -> &GPSValue {
+        &self.longitude
+    }
+
+    pub fn latitude(&self) -> &GPSValue {
+        &self.latitude
     }
 }
 

--- a/lib/entry/libimagentrygps/src/types.rs
+++ b/lib/entry/libimagentrygps/src/types.rs
@@ -18,6 +18,9 @@
 //
 
 use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 
 use toml::Value;
 
@@ -96,6 +99,12 @@ impl FromValue for GPSValue {
 
 }
 
+impl Display for GPSValue {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}° {}\" {}'", self.degree, self.minutes, self.seconds)
+    }
+}
+
 /// Data-transfer type for transfering longitude-latitude-pairs
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Coordinates {
@@ -143,6 +152,12 @@ impl FromValue for Coordinates {
         }
     }
 
+}
+
+impl Display for Coordinates {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "longitude = {}\nlatitude = {}", self.longitude, self.latitude)
+    }
 }
 
 /// Helper to convert a i64 to i8 or return an error if this doesn't work.


### PR DESCRIPTION
Required by the `imag-gps` plumbing command.