### PR TITLE
Add multi-destination logging to logger

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -25,6 +25,8 @@ This section contains the changelog from the last release to the next release.
     * `imag-view` uses the configuration file now to find the command to call
       for viewing the entry. This way one can view the entry in an editor or the
       browser or on the toaster.
+    * The logger is now able to handle multiple destinations (file and "-" for
+      stderr)
 
 ## 0.4.0
 


### PR DESCRIPTION
The logger was not able to handle multiple destinations before. Now it
is possible for the logger.

The file must be held behind an Arc<Mutex<_>> so we can use the logging
from multiple threads but also because we need to borrow mutably, so
that bit changes whith this commit.