### PR TITLE
Move handlebars custom helpers to libimaginteraction

### DIFF
--- a/lib/core/libimagrt/Cargo.toml
+++ b/lib/core/libimagrt/Cargo.toml
@@ -29,6 +29,7 @@ handlebars = "0.29.0"
 libimagstore = { version = "0.5.0", path = "../../../lib/core/libimagstore" }
 libimagerror = { version = "0.5.0", path = "../../../lib/core/libimagerror" }
 libimagutil  = { version = "0.5.0", path = "../../../lib/etc/libimagutil" }
+libimaginteraction = { version = "0.5.0", path = "../../../lib/etc/libimaginteraction" }
 
 [features]
 default = []

--- a/lib/core/libimagrt/src/lib.rs
+++ b/lib/core/libimagrt/src/lib.rs
@@ -51,6 +51,7 @@ extern crate toml_query;
 extern crate libimagstore;
 extern crate libimagutil;
 extern crate libimagerror;
+extern crate libimaginteraction;
 
 pub mod error;
 pub mod configuration;

--- a/lib/core/libimagrt/src/logger.rs
+++ b/lib/core/libimagrt/src/logger.rs
@@ -35,6 +35,7 @@ use log::{Log, LogLevel, LogRecord, LogMetadata};
 use toml::Value;
 use toml_query::read::TomlValueReadExt;
 use handlebars::Handlebars;
+use libimaginteraction::format::*;
 
 type ModuleName = String;
 type Result<T> = ::std::result::Result<T, RE>;
@@ -82,19 +83,19 @@ impl ImagLogger {
 
         handlebars.register_escape_fn(::handlebars::no_escape);
 
-        handlebars.register_helper("black"  , Box::new(self::template_helpers::ColorizeBlackHelper));
-        handlebars.register_helper("blue"   , Box::new(self::template_helpers::ColorizeBlueHelper));
-        handlebars.register_helper("cyan"   , Box::new(self::template_helpers::ColorizeCyanHelper));
-        handlebars.register_helper("green"  , Box::new(self::template_helpers::ColorizeGreenHelper));
-        handlebars.register_helper("purple" , Box::new(self::template_helpers::ColorizePurpleHelper));
-        handlebars.register_helper("red"    , Box::new(self::template_helpers::ColorizeRedHelper));
-        handlebars.register_helper("white"  , Box::new(self::template_helpers::ColorizeWhiteHelper));
-        handlebars.register_helper("yellow" , Box::new(self::template_helpers::ColorizeYellowHelper));
+        handlebars.register_helper("black"  , Box::new(ColorizeBlackHelper));
+        handlebars.register_helper("blue"   , Box::new(ColorizeBlueHelper));
+        handlebars.register_helper("cyan"   , Box::new(ColorizeCyanHelper));
+        handlebars.register_helper("green"  , Box::new(ColorizeGreenHelper));
+        handlebars.register_helper("purple" , Box::new(ColorizePurpleHelper));
+        handlebars.register_helper("red"    , Box::new(ColorizeRedHelper));
+        handlebars.register_helper("white"  , Box::new(ColorizeWhiteHelper));
+        handlebars.register_helper("yellow" , Box::new(ColorizeYellowHelper));
 
-        handlebars.register_helper("underline"     , Box::new(self::template_helpers::UnderlineHelper));
-        handlebars.register_helper("bold"          , Box::new(self::template_helpers::BoldHelper));
-        handlebars.register_helper("blink"         , Box::new(self::template_helpers::BlinkHelper));
-        handlebars.register_helper("strikethrough" , Box::new(self::template_helpers::StrikethroughHelper));
+        handlebars.register_helper("underline"     , Box::new(UnderlineHelper));
+        handlebars.register_helper("bold"          , Box::new(BoldHelper));
+        handlebars.register_helper("blink"         , Box::new(BlinkHelper));
+        handlebars.register_helper("strikethrough" , Box::new(StrikethroughHelper));
 
         {
             let fmt = try!(aggregate_global_format_trace(matches, config));
@@ -476,143 +477,5 @@ fn aggregate_module_settings(_matches: &ArgMatches, config: Option<&Configuratio
             Ok(BTreeMap::new())
         }
     }
-}
-
-mod template_helpers {
-    use handlebars::{Handlebars, HelperDef, JsonRender, RenderError, RenderContext, Helper};
-    use ansi_term::Colour;
-    use ansi_term::Style;
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeBlackHelper;
-
-    impl HelperDef for ColorizeBlackHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Black, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeBlueHelper;
-
-    impl HelperDef for ColorizeBlueHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Blue, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeCyanHelper;
-
-    impl HelperDef for ColorizeCyanHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Cyan, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeGreenHelper;
-
-    impl HelperDef for ColorizeGreenHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Green, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizePurpleHelper;
-
-    impl HelperDef for ColorizePurpleHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Purple, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeRedHelper;
-
-    impl HelperDef for ColorizeRedHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Red, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeWhiteHelper;
-
-    impl HelperDef for ColorizeWhiteHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::White, h, hb, rc)
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct ColorizeYellowHelper;
-
-    impl HelperDef for ColorizeYellowHelper {
-        fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-            colorize(Colour::Yellow, h, hb, rc)
-        }
-    }
-
-    fn colorize(color: Colour, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-        let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
-
-        try!(write!(rc.writer(), "{}", color.paint(p.value().render())));
-        Ok(())
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct UnderlineHelper;
-
-    impl HelperDef for UnderlineHelper {
-        fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
-            RenderError> {
-                let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
-                let s = Style::new().underline();
-                try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
-                Ok(())
-            }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct BoldHelper;
-
-    impl HelperDef for BoldHelper {
-        fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
-            RenderError> {
-                let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
-                let s = Style::new().bold();
-                try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
-                Ok(())
-            }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct BlinkHelper;
-
-    impl HelperDef for BlinkHelper {
-        fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
-            RenderError> {
-                let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
-                let s = Style::new().blink();
-                try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
-                Ok(())
-            }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct StrikethroughHelper;
-
-    impl HelperDef for StrikethroughHelper {
-        fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
-            RenderError> {
-                let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
-                let s = Style::new().strikethrough();
-                try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
-                Ok(())
-            }
-    }
-
 }
 

--- a/lib/core/libimagrt/src/logger.rs
+++ b/lib/core/libimagrt/src/logger.rs
@@ -35,7 +35,6 @@ use log::{Log, LogLevel, LogRecord, LogMetadata};
 use toml::Value;
 use toml_query::read::TomlValueReadExt;
 use handlebars::Handlebars;
-use libimaginteraction::format::*;
 
 type ModuleName = String;
 type Result<T> = ::std::result::Result<T, RE>;
@@ -83,19 +82,8 @@ impl ImagLogger {
 
         handlebars.register_escape_fn(::handlebars::no_escape);
 
-        handlebars.register_helper("black"  , Box::new(ColorizeBlackHelper));
-        handlebars.register_helper("blue"   , Box::new(ColorizeBlueHelper));
-        handlebars.register_helper("cyan"   , Box::new(ColorizeCyanHelper));
-        handlebars.register_helper("green"  , Box::new(ColorizeGreenHelper));
-        handlebars.register_helper("purple" , Box::new(ColorizePurpleHelper));
-        handlebars.register_helper("red"    , Box::new(ColorizeRedHelper));
-        handlebars.register_helper("white"  , Box::new(ColorizeWhiteHelper));
-        handlebars.register_helper("yellow" , Box::new(ColorizeYellowHelper));
-
-        handlebars.register_helper("underline"     , Box::new(UnderlineHelper));
-        handlebars.register_helper("bold"          , Box::new(BoldHelper));
-        handlebars.register_helper("blink"         , Box::new(BlinkHelper));
-        handlebars.register_helper("strikethrough" , Box::new(StrikethroughHelper));
+        ::libimaginteraction::format::register_all_color_helpers(&mut handlebars);
+        ::libimaginteraction::format::register_all_format_helpers(&mut handlebars);
 
         {
             let fmt = try!(aggregate_global_format_trace(matches, config));

--- a/lib/etc/libimaginteraction/Cargo.toml
+++ b/lib/etc/libimaginteraction/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.3"
 regex = "0.2"
 toml = "0.4"
 error-chain = "0.10"
+handlebars = "0.29.0"
 
 libimagstore       = { version = "0.5.0", path = "../../../lib/core/libimagstore" }
 libimagerror       = { version = "0.5.0", path = "../../../lib/core/libimagerror" }

--- a/lib/etc/libimaginteraction/src/format.rs
+++ b/lib/etc/libimaginteraction/src/format.rs
@@ -152,3 +152,21 @@ impl HelperDef for StrikethroughHelper {
         }
 }
 
+pub fn register_all_color_helpers(handlebars: &mut Handlebars) {
+    handlebars.register_helper("black"  , Box::new(ColorizeBlackHelper));
+    handlebars.register_helper("blue"   , Box::new(ColorizeBlueHelper));
+    handlebars.register_helper("cyan"   , Box::new(ColorizeCyanHelper));
+    handlebars.register_helper("green"  , Box::new(ColorizeGreenHelper));
+    handlebars.register_helper("purple" , Box::new(ColorizePurpleHelper));
+    handlebars.register_helper("red"    , Box::new(ColorizeRedHelper));
+    handlebars.register_helper("white"  , Box::new(ColorizeWhiteHelper));
+    handlebars.register_helper("yellow" , Box::new(ColorizeYellowHelper));
+}
+
+pub fn register_all_format_helpers(handlebars: &mut Handlebars) {
+    handlebars.register_helper("underline"     , Box::new(UnderlineHelper));
+    handlebars.register_helper("bold"          , Box::new(BoldHelper));
+    handlebars.register_helper("blink"         , Box::new(BlinkHelper));
+    handlebars.register_helper("strikethrough" , Box::new(StrikethroughHelper));
+}
+

--- a/lib/etc/libimaginteraction/src/format.rs
+++ b/lib/etc/libimaginteraction/src/format.rs
@@ -1,0 +1,154 @@
+//
+// imag - the personal information management suite for the commandline
+// Copyright (C) 2015, 2016 Matthias Beyer <mail@beyermatthias.de> and contributors
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 of the License.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+use handlebars::{Handlebars, HelperDef, JsonRender, RenderError, RenderContext, Helper};
+use ansi_term::Colour;
+use ansi_term::Style;
+
+#[derive(Clone, Copy)]
+pub struct ColorizeBlackHelper;
+
+impl HelperDef for ColorizeBlackHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Black, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizeBlueHelper;
+
+impl HelperDef for ColorizeBlueHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Blue, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizeCyanHelper;
+
+impl HelperDef for ColorizeCyanHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Cyan, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizeGreenHelper;
+
+impl HelperDef for ColorizeGreenHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Green, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizePurpleHelper;
+
+impl HelperDef for ColorizePurpleHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Purple, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizeRedHelper;
+
+impl HelperDef for ColorizeRedHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Red, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizeWhiteHelper;
+
+impl HelperDef for ColorizeWhiteHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::White, h, hb, rc)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ColorizeYellowHelper;
+
+impl HelperDef for ColorizeYellowHelper {
+    fn call(&self, h: &Helper, hb: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+        colorize(Colour::Yellow, h, hb, rc)
+    }
+}
+
+fn colorize(color: Colour, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+    let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
+
+    try!(write!(rc.writer(), "{}", color.paint(p.value().render())));
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+pub struct UnderlineHelper;
+
+impl HelperDef for UnderlineHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
+        RenderError> {
+            let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
+            let s = Style::new().underline();
+            try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
+            Ok(())
+        }
+}
+
+#[derive(Clone, Copy)]
+pub struct BoldHelper;
+
+impl HelperDef for BoldHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
+        RenderError> {
+            let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
+            let s = Style::new().bold();
+            try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
+            Ok(())
+        }
+}
+
+#[derive(Clone, Copy)]
+pub struct BlinkHelper;
+
+impl HelperDef for BlinkHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
+        RenderError> {
+            let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
+            let s = Style::new().blink();
+            try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
+            Ok(())
+        }
+}
+
+#[derive(Clone, Copy)]
+pub struct StrikethroughHelper;
+
+impl HelperDef for StrikethroughHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(),
+        RenderError> {
+            let p = try!(h.param(0).ok_or(RenderError::new("Too few arguments")));
+            let s = Style::new().strikethrough();
+            try!(write!(rc.writer(), "{}", s.paint(p.value().render())));
+            Ok(())
+        }
+}
+

--- a/lib/etc/libimaginteraction/src/lib.rs
+++ b/lib/etc/libimaginteraction/src/lib.rs
@@ -41,6 +41,7 @@ extern crate ansi_term;
 extern crate regex;
 extern crate clap;
 extern crate toml;
+extern crate handlebars;
 #[macro_use] extern crate error_chain;
 
 extern crate libimagstore;
@@ -49,5 +50,6 @@ extern crate libimagerror;
 pub mod ask;
 pub mod error;
 pub mod filter;
+pub mod format;
 pub mod ui;
 


### PR DESCRIPTION
I moved this code because we need handlebars in various places, I would say. Hence having a library which contains all our helpers would be neat, IMO.

I actually need helpers in the `imag-contact` implementation, so this blocks the implementation of `imag-contact` in a certain way.