### PR TITLE
travis: rustc 1.17/1.18 -> 1.19/1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ dist:
 language: rust
 
 rust:
-  - 1.17.0
-  - 1.18.0
+  - 1.19.0
+  - 1.20.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
We want to be able to compile imag with the latest compiler, but also
two compilers before the current one.

So Update the travis spec to include rustc 1.19 and 1.20, but not 1.17
and 1.18 anymore.