### PR TITLE
Fix Store::entries() to not yield directories

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -34,6 +34,10 @@ This section contains the changelog from the last release to the next release.
       anymore. This is minor because `libimagentryanntation` is not yet used by
       any other crate.
 
+* Bugfixes
+    * `Store::entries()` does not yield StoreIds which point to directories
+      anymore, only StoreIds pointing to files.
+
 ## 0.4.0
 
 * Major changes

--- a/lib/core/libimagstore/src/file_abstraction/fs.rs
+++ b/lib/core/libimagstore/src/file_abstraction/fs.rs
@@ -150,6 +150,10 @@ impl FileAbstraction for FSFileAbstraction {
         Ok(path.exists())
     }
 
+    fn is_file(&self, path: &PathBuf) -> Result<bool, SE> {
+        Ok(path.is_file())
+    }
+
     fn new_instance(&self, p: PathBuf) -> Box<FileAbstractionInstance> {
         Box::new(FSFileAbstractionInstance::Absent(p))
     }

--- a/lib/core/libimagstore/src/file_abstraction/inmemory.rs
+++ b/lib/core/libimagstore/src/file_abstraction/inmemory.rs
@@ -159,6 +159,13 @@ impl FileAbstraction for InMemoryFileAbstraction {
         Ok(backend.contains_key(pb))
     }
 
+    fn is_file(&self, pb: &PathBuf) -> Result<bool, SE> {
+        // Because we only store Entries in the memory-internal backend, we only have to check for
+        // existance here, as if a path exists in the inmemory storage, it is always mapped to an
+        // entry. hence it is always a path to a file
+        self.exists(pb)
+    }
+
     fn new_instance(&self, p: PathBuf) -> Box<FileAbstractionInstance> {
         Box::new(InMemoryFileAbstractionInstance::new(self.backend().clone(), p))
     }

--- a/lib/core/libimagstore/src/file_abstraction/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/mod.rs
@@ -44,6 +44,7 @@ pub trait FileAbstraction : Debug {
     fn create_dir_all(&self, _: &PathBuf) -> Result<(), SE>;
 
     fn exists(&self, &PathBuf) -> Result<bool, SE>;
+    fn is_file(&self, &PathBuf) -> Result<bool, SE>;
 
     fn new_instance(&self, p: PathBuf) -> Box<FileAbstractionInstance>;
 

--- a/lib/core/libimagstore/src/file_abstraction/stdio/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/stdio/mod.rs
@@ -119,6 +119,10 @@ impl<W: Write, M: Mapper> FileAbstraction for StdIoFileAbstraction<W, M> {
         self.0.exists(p)
     }
 
+    fn is_file(&self, p: &PathBuf) -> Result<bool, SE> {
+        self.0.is_file(p)
+    }
+
     fn drain(&self) -> Result<Drain, SE> {
         self.0.drain()
     }

--- a/lib/core/libimagstore/src/file_abstraction/stdio/out.rs
+++ b/lib/core/libimagstore/src/file_abstraction/stdio/out.rs
@@ -140,6 +140,10 @@ impl<W: Write, M: Mapper> FileAbstraction for StdoutFileAbstraction<W, M> {
         self.mem.exists(p)
     }
 
+    fn is_file(&self, p: &PathBuf) -> Result<bool, SE> {
+        self.mem.is_file(p)
+    }
+
     fn drain(&self) -> Result<Drain, SE> {
         self.backend_cloned().map(Drain::new)
     }


### PR DESCRIPTION
Before the iterator did also yield storeids for directories, which was a
bug.