### PR TITLE
Update travis rustc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ dist:
 language: rust
 
 rust:
-  - 1.19.0
   - 1.20.0
+  - 1.21.0
+  - 1.22.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
The 'bitflags' dependency requires rustc 1.20 as minimum version, hence
remove 1.19.

Also add the newer rustc versions in the CI chain.