### PR TITLE
libimagstore: use toml::Value::as_str() (for example)

### DIFF
--- a/lib/core/libimagstore/src/configuration.rs
+++ b/lib/core/libimagstore/src/configuration.rs
@@ -23,11 +23,11 @@ use store::Result;
 use error::StoreError as SE;
 use error::StoreErrorKind as SEK;
 
-use toml_query::read::TomlValueReadExt;
-
 /// Checks whether the store configuration has a key "implicit-create" which maps to a boolean
 /// value. If that key is present, the boolean is returned, otherwise false is returned.
 pub fn config_implicit_store_create_allowed(config: &Option<Value>) -> Result<bool> {
+    use toml_query::read::TomlValueReadExt;
+
     let key = "store.implicit-create";
 
     if let Some(ref t) = *config {

--- a/lib/core/libimagstore/src/store.rs
+++ b/lib/core/libimagstore/src/store.rs
@@ -1149,14 +1149,6 @@ mod test {
     }
 
     #[test]
-    fn test_imag_invalid_section_type() {
-        let mut map = BTreeMap::new();
-        map.insert("imag".into(), Value::Boolean(false));
-
-        assert!(!has_main_section(&map));
-    }
-
-    #[test]
     fn test_imag_abscent_main_section() {
         let mut map = BTreeMap::new();
         map.insert("not_imag".into(), Value::Boolean(false));


### PR DESCRIPTION
Some refactorings and simplifications in the imag store.

Rel: #1173 