### PR TITLE
Do not copy imag sources to nix store

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,7 +22,7 @@ in
 
 pkgs.stdenv.mkDerivation rec {
     name = "imag";
-    src = ./.;
+    src = /var/empty;
     version = "0.0.0";
 
     buildInputs = env ++ dependencies;


### PR DESCRIPTION
The imag codebase was copied to the nix store when using the `default.nix` file... which is a thing we don't have to do to build imag.

This fixes this.