### PR TITLE
Rename `Store::retrieve_copy` to `Store::get_copy`

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -26,6 +26,9 @@ This section contains the changelog from the last release to the next release.
     * `imag-log` was introduced
     * `imag-init` was introduced
     * `libimagdiary` supports second-granularity now.
+    * `libimagstore::store::Store::retrieve_copy` was renamed to
+      `libimagstore::store::Store::get_copy`, which describes the semantics of
+      the function way better.
 * Minor changes
     * Internals were refactored from `match`ing all the things into function
       chaining

--- a/lib/core/libimagstore/src/store.rs
+++ b/lib/core/libimagstore/src/store.rs
@@ -502,8 +502,7 @@ impl Store {
         Ok(())
     }
 
-    /// Retrieve a copy of a given entry, this cannot be used to mutate
-    /// the one on disk
+    /// Get a copy of a given entry, this cannot be used to mutate the one on disk
     ///
     /// # Return value
     ///
@@ -514,7 +513,7 @@ impl Store {
     ///  - RetrieveCopyCallError(IdLocked()) if the Entry is borrowed currently
     ///  - Errors StoreEntry::new() might return
     ///
-    pub fn retrieve_copy<S: IntoStoreId>(&self, id: S) -> Result<Entry> {
+    pub fn get_copy<S: IntoStoreId>(&self, id: S) -> Result<Entry> {
         let id = id.into_storeid()?.with_base(self.path().clone());
         debug!("Retrieving copy of '{}'", id);
         let entries = self.entries.write()


### PR DESCRIPTION
The function was named falsely and nobody noticed. So nobody uses this
function yet - hopefully - as this change is a breaking API change.
  
---

Relates to #1205 