### PR TITLE
Date string conversion util to libimagutil

### DIFF
--- a/bin/domain/imag-habit/src/main.rs
+++ b/bin/domain/imag-habit/src/main.rs
@@ -372,7 +372,7 @@ fn show(rt: &Runtime) {
     }
 
     fn instance_lister_fn(i: &FileLockEntry) -> Vec<String> {
-        use libimaghabit::util::date_to_string;
+        use libimagutil::date::date_to_string;
         use libimaghabit::instance::HabitInstance;
 
         let date = date_to_string(&i.get_date().map_err_trace_exit_unwrap(1));
@@ -456,7 +456,7 @@ fn done(rt: &Runtime) {
                 .map_err_trace_exit_unwrap(1);
 
             info!("Done on {date}: {name}",
-                  date = libimaghabit::util::date_to_string(&next),
+                  date = libimagutil::date::date_to_string(&next),
                   name = next_instance_name);
         } else {
             info!("Ignoring: {}, because there is no due date (the habit is finised)",
@@ -483,6 +483,6 @@ fn get_from_store<'a>(store: &'a Store, id: StoreId) -> Option<FileLockEntry<'a>
 }
 
 fn date_to_string_helper(d: chrono::NaiveDate) -> String {
-    libimaghabit::util::date_to_string(&d)
+    libimagutil::date::date_to_string(&d)
 }
 

--- a/lib/domain/libimaghabit/Cargo.toml
+++ b/lib/domain/libimaghabit/Cargo.toml
@@ -26,3 +26,4 @@ libimagerror     = { version = "0.6.0", path = "../../../lib/core/libimagerror" 
 libimagentryedit = { version = "0.6.0", path = "../../../lib/entry/libimagentryedit" }
 libimagentrylink = { version = "0.6.0", path = "../../../lib/entry/libimagentrylink" }
 libimagentryutil = { version = "0.6.0", path = "../../../lib/entry/libimagentryutil" }
+libimagutil      = { version = "0.6.0", path = "../../../lib/etc/libimagutil" }

--- a/lib/domain/libimaghabit/src/habit.rs
+++ b/lib/domain/libimaghabit/src/habit.rs
@@ -28,7 +28,6 @@ use error::HabitError as HE;
 use error::HabitErrorKind as HEK;
 use error::*;
 use iter::HabitInstanceStoreIdIterator;
-use util::date_to_string;
 use util::IsHabitCheck;
 use util::get_string_header_from_entry;
 use instance::IsHabitInstance;
@@ -42,6 +41,7 @@ use libimagstore::storeid::IntoStoreId;
 use libimagstore::storeid::StoreIdIterator;
 use libimagentryutil::isa::Is;
 use libimagentryutil::isa::IsKindHeaderPathProvider;
+use libimagutil::date::date_to_string;
 
 /// A HabitTemplate is a "template" of a habit. A user may define a habit "Eat vegetable".
 /// If the user ate a vegetable, she should create a HabitInstance from the Habit with the
@@ -250,7 +250,7 @@ pub mod builder {
     use error::HabitError as HE;
     use error::HabitErrorKind as HEK;
     use error::*;
-    use util::date_to_string;
+    use libimagutil::date::date_to_string;
     use habit::IsHabitTemplate;
 
     pub struct HabitBuilder {

--- a/lib/domain/libimaghabit/src/instance.rs
+++ b/lib/domain/libimaghabit/src/instance.rs
@@ -54,11 +54,13 @@ impl HabitInstance for Entry {
     }
 
     fn get_date(&self) -> Result<NaiveDate> {
-        use util::date_from_string;
+        use libimagutil::date::date_from_string as dts;
+        let date_from_string = |d| dts(d).map_err(From::from);
         get_string_header_from_entry(self, "habit.instance.date").and_then(date_from_string)
     }
 
     fn set_date(&mut self, n: &NaiveDate) -> Result<()> {
+        use libimagutil::date::date_to_string;
         // Using `set` here because when creating the entry, these headers should be made present.
         self.get_header_mut()
             .set("habit.instance.date", Value::String(date_to_string(n)))

--- a/lib/domain/libimaghabit/src/util.rs
+++ b/lib/domain/libimaghabit/src/util.rs
@@ -19,7 +19,6 @@
 
 use std::ops::BitXor;
 
-use chrono::NaiveDate;
 use error::Result;
 
 use habit::HabitTemplate;
@@ -27,16 +26,6 @@ use instance::HabitInstance;
 
 use libimagstore::storeid::StoreId;
 use libimagstore::store::Entry;
-
-pub const NAIVE_DATE_STRING_FORMAT : &'static str = "%Y-%m-%d";
-
-pub fn date_to_string(ndt: &NaiveDate) -> String {
-    ndt.format(NAIVE_DATE_STRING_FORMAT).to_string()
-}
-
-pub fn date_from_string(s: String) -> Result<NaiveDate> {
-    NaiveDate::parse_from_str(&s, NAIVE_DATE_STRING_FORMAT).map_err(From::from)
-}
 
 /// Helper trait to check whether a object which can be a habit instance and a habit template is
 /// actually a valid object, whereas "valid" is defined that it is _either_ an instance or a

--- a/lib/etc/libimagutil/Cargo.toml
+++ b/lib/etc/libimagutil/Cargo.toml
@@ -32,4 +32,5 @@ lazy_static = "0.2"
 log = "0.4.0"
 regex = "0.2"
 tempfile = "2.1"
+chrono = "0.4"
 

--- a/lib/etc/libimagutil/src/date.rs
+++ b/lib/etc/libimagutil/src/date.rs
@@ -18,6 +18,7 @@
 //
 
 use chrono::NaiveDate;
+use chrono::NaiveDateTime;
 use chrono::format::ParseError;
 
 pub const NAIVE_DATE_STRING_FORMAT : &'static str = "%Y-%m-%d";
@@ -28,5 +29,15 @@ pub fn date_to_string(ndt: &NaiveDate) -> String {
 
 pub fn date_from_string(s: String) -> Result<NaiveDate, ParseError> {
     NaiveDate::parse_from_str(&s, NAIVE_DATE_STRING_FORMAT)
+}
+
+pub const NAIVE_DATETIME_STRING_FORMAT : &'static str = "%Y-%m-%d %H:%M:%S";
+
+pub fn datetime_to_string(ndt: &NaiveDateTime) -> String {
+    ndt.format(NAIVE_DATETIME_STRING_FORMAT).to_string()
+}
+
+pub fn datetime_from_string(s: &str) -> Result<NaiveDateTime, ParseError> {
+    NaiveDateTime::parse_from_str(s, NAIVE_DATETIME_STRING_FORMAT)
 }
 

--- a/lib/etc/libimagutil/src/date.rs
+++ b/lib/etc/libimagutil/src/date.rs
@@ -27,8 +27,10 @@ pub fn date_to_string(ndt: &NaiveDate) -> String {
     ndt.format(NAIVE_DATE_STRING_FORMAT).to_string()
 }
 
-pub fn date_from_string(s: String) -> Result<NaiveDate, ParseError> {
-    NaiveDate::parse_from_str(&s, NAIVE_DATE_STRING_FORMAT)
+pub fn date_from_string<S>(s: S) -> Result<NaiveDate, ParseError>
+    where S: AsRef<str>
+{
+    NaiveDate::parse_from_str(s.as_ref(), NAIVE_DATE_STRING_FORMAT)
 }
 
 pub const NAIVE_DATETIME_STRING_FORMAT : &'static str = "%Y-%m-%d %H:%M:%S";
@@ -37,7 +39,9 @@ pub fn datetime_to_string(ndt: &NaiveDateTime) -> String {
     ndt.format(NAIVE_DATETIME_STRING_FORMAT).to_string()
 }
 
-pub fn datetime_from_string(s: &str) -> Result<NaiveDateTime, ParseError> {
-    NaiveDateTime::parse_from_str(s, NAIVE_DATETIME_STRING_FORMAT)
+pub fn datetime_from_string<S>(s: S) -> Result<NaiveDateTime, ParseError>
+    where S: AsRef<str>
+{
+    NaiveDateTime::parse_from_str(s.as_ref(), NAIVE_DATETIME_STRING_FORMAT)
 }
 

--- a/lib/etc/libimagutil/src/date.rs
+++ b/lib/etc/libimagutil/src/date.rs
@@ -17,27 +17,16 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-extern crate chrono;
-extern crate toml;
-extern crate toml_query;
-extern crate kairos;
-#[macro_use] extern crate log;
-#[macro_use] extern crate error_chain;
+use chrono::NaiveDate;
+use chrono::format::ParseError;
 
-#[macro_use] extern crate libimagstore;
-extern crate libimagerror;
-extern crate libimagentryedit;
-extern crate libimagentrylink;
-#[macro_use] extern crate libimagentryutil;
-extern crate libimagutil;
+pub const NAIVE_DATE_STRING_FORMAT : &'static str = "%Y-%m-%d";
 
-module_entry_path_mod!("habit");
+pub fn date_to_string(ndt: &NaiveDate) -> String {
+    ndt.format(NAIVE_DATE_STRING_FORMAT).to_string()
+}
 
-pub mod error;
-pub mod habit;
-pub mod instance;
-pub mod iter;
-pub mod result;
-pub mod store;
-pub mod util;
+pub fn date_from_string(s: String) -> Result<NaiveDate, ParseError> {
+    NaiveDate::parse_from_str(&s, NAIVE_DATE_STRING_FORMAT)
+}
 

--- a/lib/etc/libimagutil/src/lib.rs
+++ b/lib/etc/libimagutil/src/lib.rs
@@ -39,9 +39,11 @@ extern crate regex;
 extern crate url;
 extern crate boolinator;
 extern crate tempfile;
+extern crate chrono;
 
 #[macro_use] mod log_result;
 pub mod cli_validators;
+pub mod date;
 pub mod debug_result;
 pub mod edit;
 pub mod info_result;


### PR DESCRIPTION
By moving this utility to `libimagutil` we now have a standard way of transforming these things (mainly a standard format for imag).

Question: Should we add timezone information in the format? I suppose not, because this is a single-user thing and the user should not care about timezones, should she?