### PR TITLE
Reduce number of build-jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,9 @@ dist:
 language: rust
 
 rust:
-  - 1.21.0
   - 1.22.1
   - 1.23.0
   - stable
-  - beta
-  - nightly
-
-matrix:
-  allow_failures:
-    - rust: nightly
 
 cache:
   cargo: true


### PR DESCRIPTION
Currently we have build times up to 2 hours. That's because travis does
not execute all builds in parallel, but some in sequence (afaik 4 are
run in parallel).

Because of that, we have build times up to 2 hours.

By removing the builds for 1.21 (which is old, 1.24 came out 3 days ago)
and for beta and nightly, we reduce the number of jobs for each build to
3 and thus the overall build time, hopefully.