### PR TITLE
Simplify Store debug impl

### DIFF
--- a/lib/core/libimagstore/src/store.rs
+++ b/lib/core/libimagstore/src/store.rs
@@ -752,10 +752,7 @@ impl Store {
 impl Debug for Store {
 
     fn fmt(&self, fmt: &mut Formatter) -> RResult<(), FMTError> {
-        write!(fmt,
-               r#"Store\n\tlocation = {:?}\n\tentries = {:?}\n"#,
-               self.location,
-               self.entries)
+        writeln!(fmt, "Store location = {:?}, entries = {:?}", self.location, self.entries)
     }
 
 }


### PR DESCRIPTION
The output was ugly before, as `\t` and `\n` did not get expanded.