### PR TITLE
Fix order of evaluation

### DIFF
--- a/bin/domain/imag-diary/src/util.rs
+++ b/bin/domain/imag-diary/src/util.rs
@@ -26,8 +26,10 @@ use toml_query::read::TomlValueReadExt;
 pub fn get_diary_name(rt: &Runtime) -> Option<String> {
     use libimagdiary::config::get_default_diary_name;
 
-    get_default_diary_name(rt)
-        .or(rt.cli().value_of("diaryname").map(String::from))
+    rt.cli()
+        .value_of("diaryname")
+        .map(String::from)
+        .or_else(|| get_default_diary_name(rt))
 }
 
 pub enum Timed {


### PR DESCRIPTION
We need to evaluate the commandline argument first and if there is none,
we use the default.

This patch fixes that bug.

---

Closes #1300 