### PR TITLE
Rewrite entry parsing algorithm

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -58,6 +58,8 @@ This section contains the changelog from the last release to the next release.
       default.
     * `libimagerror` printed errors with `write!()` rather than `writeln!()`
       when tracing.
+    * A parsing error in `libimagstore`, which caused the parsing of entries
+      with a line "---" in the content part to fail, was fixed.
 
 
 ## 0.6.1

--- a/lib/core/libimagstore/Cargo.toml
+++ b/lib/core/libimagstore/Cargo.toml
@@ -21,7 +21,6 @@ maintenance                       = { status     = "actively-developed" }
 
 [dependencies]
 glob = "0.2.11"
-lazy_static = "0.2"
 log = "0.4.0"
 regex = "0.2"
 semver = "0.8"

--- a/lib/core/libimagstore/src/error.rs
+++ b/lib/core/libimagstore/src/error.rs
@@ -28,6 +28,7 @@ error_chain! {
 
     foreign_links {
         Io(::std::io::Error);
+        Fmt(::std::fmt::Error);
         TomlDeserError(::toml::de::Error);
         GlobPatternError(::glob::PatternError);
         TomlQueryError(::toml_query::error::Error);

--- a/lib/core/libimagstore/src/lib.rs
+++ b/lib/core/libimagstore/src/lib.rs
@@ -37,7 +37,6 @@
 
 #[macro_use] extern crate log;
 extern crate glob;
-#[macro_use] extern crate lazy_static;
 extern crate regex;
 extern crate toml;
 #[cfg(test)] extern crate tempdir;


### PR DESCRIPTION
Rewrite without regex crate.

The regex approach was broken. If the following _content_ was provided
in the entry:

    foo

    ---

    bar

The regex approach parsed the header until the "---" in the content.
This is, of course, not the way to do that.

Now, the parsing is implemented by hand. Should be faster as well,
though I don't care about this.

This fixes a severe bug.