### PR TITLE
Change "imag" impl to not instantiate Runtime object

### DIFF
--- a/bin/core/imag/Cargo.toml
+++ b/bin/core/imag/Cargo.toml
@@ -26,6 +26,7 @@ walkdir = "1"
 log = "0.4.0"
 toml = "0.4"
 toml-query = "0.6"
+is-match = "0.1"
 
 libimagrt    = { version = "0.7.0", path = "../../../lib/core/libimagrt" }
 libimagerror = { version = "0.7.0", path = "../../../lib/core/libimagerror" }

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -440,7 +440,8 @@ impl<'a> Runtime<'a> {
     }
 }
 
-fn get_rtp_match<'a>(matches: &ArgMatches<'a>) -> PathBuf {
+/// Exported for the `imag` command, you probably do not want to use that.
+pub fn get_rtp_match<'a>(matches: &ArgMatches<'a>) -> PathBuf {
     use std::env;
 
     matches.value_of(Runtime::arg_runtimepath_name())


### PR DESCRIPTION
Adapt libimagrt interface to export the functions we need to do this.
This is not that nice, but the best approach without rewriting large
parts of libimagrt.

---

Closes #1233 
