### PR TITLE
libimagstore: fix read into single line bug

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -60,6 +60,8 @@ This section contains the changelog from the last release to the next release.
       when tracing.
     * A parsing error in `libimagstore`, which caused the parsing of entries
       with a line "---" in the content part to fail, was fixed.
+    * The patch explained by the point above introduced a bug which caused
+      entries to be read as a single line, which was fixed as well.
 
 
 ## 0.6.1

--- a/lib/core/libimagstore/src/file_abstraction/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/mod.rs
@@ -123,5 +123,26 @@ Hello World"#).unwrap();
         assert_eq!(bah.get_content(), "Hello World");
     }
 
+    #[test]
+    fn lazy_file_multiline() {
+        let fs = InMemoryFileAbstraction::new();
+
+        let mut path = PathBuf::from("tests");
+        path.set_file_name("test1");
+        let mut lf = InMemoryFileAbstractionInstance::new(fs.backend().clone(), path.clone());
+
+        let loca = StoreId::new_baseless(path).unwrap();
+        let file = Entry::from_str(loca.clone(), r#"---
+[imag]
+version = "0.7.0"
+---
+Hello World
+baz"#).unwrap();
+
+        lf.write_file_content(&file).unwrap();
+        let bah = lf.get_file_content(loca).unwrap();
+        assert_eq!(bah.get_content(), "Hello World\nbaz");
+    }
+
 }
 

--- a/lib/core/libimagstore/src/util.rs
+++ b/lib/core/libimagstore/src/util.rs
@@ -46,7 +46,9 @@ pub fn entry_buffer_to_header_content(buf: &str) -> Result<(Value, String)> {
     let mut content         = String::new();
     let mut header_consumed = false;
 
-    for line in buf.lines().skip(1) { // the first line is "---"
+    let mut iter = buf.lines().skip(1).peekable(); // the first line is "---"
+
+    while let Some(line) = iter.next() {
         if line == "---" {
             header_consumed = true;
             // do not further process the line
@@ -54,7 +56,11 @@ pub fn entry_buffer_to_header_content(buf: &str) -> Result<(Value, String)> {
             if !header_consumed {
                 let _ = writeln!(header, "{}", line)?;
             } else {
-                let _ = write!(content, "{}", line)?;
+                if iter.peek().is_some() {
+                    let _ = writeln!(content, "{}", line)?;
+                } else {
+                    let _ = write!(content, "{}", line)?;
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #1318 

This bug was introduced after the 0.6.0 release, so there is no need to backport this fix.