### PR TITLE
libimagdiary: Do not rely on Store::retrieve_for_module

### DIFF
--- a/bin/domain/imag-diary/src/list.rs
+++ b/bin/domain/imag-diary/src/list.rs
@@ -38,16 +38,8 @@ pub fn list(rt: &Runtime) {
     Diary::entries(rt.store(), &diaryname)
         .map_dbg_str("Ok")
         .map_err_trace_exit_unwrap(1)
-        .filter_map(|entry| {
-            entry
-                .map_dbg(|e| format!("Filtering: {:?}", e))
-                .map_err_trace() // error tracing here
-                .ok() // so we can ignore errors here
-        })
-        .for_each(|e| {
-            writeln!(out, "{}", e
-                    .get_location()
-                    .clone()
+        .for_each(|id| {
+            writeln!(out, "{}", id
                     .without_base()
                     .to_str()
                     .map_err_trace()

--- a/bin/domain/imag-diary/src/view.rs
+++ b/bin/domain/imag-diary/src/view.rs
@@ -22,6 +22,7 @@ use libimagdiary::viewer::DiaryViewer as DV;
 use libimagrt::runtime::Runtime;
 use libimagerror::trace::MapErrTrace;
 use libimagutil::warn_exit::warn_exit;
+use libimagstore::iter::get::StoreIdGetIteratorExtension;
 
 use util::get_diary_name;
 
@@ -29,9 +30,16 @@ pub fn view(rt: &Runtime) {
     let diaryname = get_diary_name(rt).unwrap_or_else(|| warn_exit("No diary name", 1));
     let hdr       = rt.cli().subcommand_matches("view").unwrap().is_present("show-header");
 
-    Diary::entries(rt.store(), &diaryname)
-        .and_then(|entries| DV::new(hdr).view_entries(entries.into_iter().filter_map(Result::ok)))
-        .map_err_trace()
-        .ok();
+    let entries = Diary::entries(rt.store(), &diaryname)
+        .map_err_trace_exit_unwrap(1)
+        .into_get_iter(rt.store())
+        .filter_map(Result::ok)
+        .map(|e| e.unwrap_or_else(|| {
+            error!("Failed to fetch entry");
+            ::std::process::exit(1)
+        }));
+
+    DV::new(hdr).view_entries(entries)
+        .map_err_trace_exit_unwrap(1);
 }
 

--- a/bin/domain/imag-log/Cargo.toml
+++ b/bin/domain/imag-log/Cargo.toml
@@ -27,6 +27,7 @@ toml = "0.4"
 toml-query = "0.6"
 is-match = "0.1"
 
+libimagstore = { version = "0.7.0", path = "../../../lib/core/libimagstore" }
 libimagrt    = { version = "0.7.0", path = "../../../lib/core/libimagrt" }
 libimagerror = { version = "0.7.0", path = "../../../lib/core/libimagerror" }
 libimagdiary = { version = "0.7.0", path = "../../../lib/domain/libimagdiary" }

--- a/lib/domain/libimagdiary/Cargo.toml
+++ b/lib/domain/libimagdiary/Cargo.toml
@@ -26,6 +26,7 @@ toml = "0.4"
 toml-query = "0.6"
 itertools = "0.7"
 error-chain = "0.11"
+filters = "0.2"
 
 libimagstore     = { version = "0.7.0", path = "../../../lib/core/libimagstore" }
 libimagerror     = { version = "0.7.0", path = "../../../lib/core/libimagerror" }

--- a/lib/domain/libimagdiary/src/lib.rs
+++ b/lib/domain/libimagdiary/src/lib.rs
@@ -41,6 +41,7 @@ extern crate toml;
 extern crate toml_query;
 extern crate itertools;
 #[macro_use] extern crate error_chain;
+extern crate filters;
 
 #[macro_use] extern crate libimagstore;
 #[macro_use] extern crate libimagentryutil;


### PR DESCRIPTION
Part of #1320 

Patch itself is ready, but the `DiaryEntryIterator` could use some rework as well, as it is not nicely designed (and its name is wrong now, that it no longer iterates over `FileLockEntry` but `StoreId`).