### PR TITLE
This fixes the file parsing (again)

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -64,6 +64,8 @@ This section contains the changelog from the last release to the next release.
     * The patch explained by the point above introduced a bug which caused
       entries to be read as a single line, which was fixed as well.
     * `imag-diary create --timed` did not work as expected
+    * `libimagstore` got another fix with the file parsing, as the
+      `std::str::Lines` iterator takes empty lines as no lines.
 
 
 ## 0.6.1

--- a/lib/core/libimagstore/src/file_abstraction/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/mod.rs
@@ -144,5 +144,28 @@ baz"#, env!("CARGO_PKG_VERSION"))).unwrap();
         assert_eq!(bah.get_content(), "Hello World\nbaz");
     }
 
+    #[test]
+    fn lazy_file_multiline_trailing_newlines() {
+        let fs = InMemoryFileAbstraction::new();
+
+        let mut path = PathBuf::from("tests");
+        path.set_file_name("test1");
+        let mut lf = InMemoryFileAbstractionInstance::new(fs.backend().clone(), path.clone());
+
+        let loca = StoreId::new_baseless(path).unwrap();
+        let file = Entry::from_str(loca.clone(), &format!(r#"---
+[imag]
+version = "{}"
+---
+Hello World
+baz
+
+"#, env!("CARGO_PKG_VERSION"))).unwrap();
+
+        lf.write_file_content(&file).unwrap();
+        let bah = lf.get_file_content(loca).unwrap();
+        assert_eq!(bah.get_content(), "Hello World\nbaz\n\n");
+    }
+
 }
 

--- a/lib/core/libimagstore/src/store.rs
+++ b/lib/core/libimagstore/src/store.rs
@@ -1207,6 +1207,14 @@ version = '0.0.3'
 ---
 Hai";
 
+    static TEST_ENTRY_TNL : &'static str = "---
+[imag]
+version = '0.0.3'
+---
+Hai
+
+";
+
     #[test]
     fn test_entry_from_str() {
         use super::Entry;
@@ -1230,6 +1238,17 @@ Hai";
         assert_eq!(TEST_ENTRY, string);
     }
 
+    #[test]
+    fn test_entry_to_str_trailing_newline() {
+        use super::Entry;
+        use std::path::PathBuf;
+        println!("{}", TEST_ENTRY_TNL);
+        let entry = Entry::from_str(StoreId::new_baseless(PathBuf::from("test/foo~1.3")).unwrap(),
+                                    TEST_ENTRY_TNL).unwrap();
+        let string = entry.to_str();
+
+        assert_eq!(TEST_ENTRY_TNL, string);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Unfortunately, our latest fix to file parsing did not solve all issues.
So we have to fix it _again_.

The problem was the `std::str::Lines` iterator, which apparently fails
this:

    assert_eq!(1, "".lines().count());

as an empty line seems not to be a line.

Because of that, when reading a file with an empty line at its bottom
got stripped off that line.

This patch removes the use of the `lines()` iterator and uses
`split("\n")` instead. This only works on Unix operating systems, but as
we only target unix operating systems with imag, this is not considered
an issue right now.

This patch also adds extensive tests on multiple levels in the
`libimagstore` implementation:

* On the parsing level, for the function which implements the parsing
* On the filesystem abstraction levels
* On the `Store` levels

to make sure that everything is parsed correctly.