### PR TITLE
libimagentryref: content ref

### DIFF
--- a/lib/entry/libimagentryref/Cargo.toml
+++ b/lib/entry/libimagentryref/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4.0"
 toml = "0.4"
 toml-query = "0.6"
 error-chain = "0.11"
+either = "1.4"
 
 libimagstore     = { version = "0.8.0", path = "../../../lib/core/libimagstore" }
 libimagerror     = { version = "0.8.0", path = "../../../lib/core/libimagerror" }

--- a/lib/entry/libimagentryref/src/lib.rs
+++ b/lib/entry/libimagentryref/src/lib.rs
@@ -39,6 +39,7 @@
 extern crate itertools;
 extern crate toml;
 extern crate toml_query;
+extern crate either;
 
 #[macro_use] extern crate libimagstore;
 extern crate libimagerror;

--- a/lib/entry/libimagentryref/src/reference.rs
+++ b/lib/entry/libimagentryref/src/reference.rs
@@ -43,6 +43,9 @@ pub trait Ref {
     /// Check whether the underlying object is actually a ref
     fn is_ref(&self) -> Result<bool>;
 
+    /// Check whether the underlying object is a content ref
+    fn is_content_ref(&self) -> Result<bool>;
+
     /// Get the stored hash.
     ///
     /// Does not need a `UniqueRefPathGenerator` as it reads the hash stored in the header
@@ -51,6 +54,12 @@ pub trait Ref {
     /// Make this object a ref
     fn make_ref<P: AsRef<Path>>(&mut self, hash: String, path: P) -> Result<()>;
 
+    /// Get the content hash, if it exists
+    ///
+    /// Does not need a `UniqueRefPathGenerator` or a `ContentHashGenerator` as it reads the hash
+    /// stored in the header.
+    fn get_content_hash(&self) -> Result<Option<&str>>;
+
     /// Get the referenced path.
     ///
     /// Does not need a `UniqueRefPathGenerator` as it reads the path stored in the header.
@@ -58,6 +67,11 @@ pub trait Ref {
 
     /// Check whether the referenced file still matches its hash
     fn hash_valid<RPG: UniqueRefPathGenerator>(&self) -> RResult<bool, RPG::Error>;
+
+    /// Check whether the referenced file still matches its content hash
+    ///
+    /// Returns Ok(None) if there is no content hash stored in the ref.
+    fn content_hash_valid<C: ContentHashGenerator>(&self, &C) -> RResult<Option<bool>, C::Error>;
 
     fn remove_ref(&mut self) -> Result<()>;
 

--- a/lib/entry/libimagentryref/src/refstore.rs
+++ b/lib/entry/libimagentryref/src/refstore.rs
@@ -48,6 +48,25 @@ pub trait UniqueRefPathGenerator {
     }
 }
 
+/// A generator for hashes which contains context information
+///
+/// This trait can be used to reference to data within a referenced file.
+/// This is useful for references where you need to refer to parts of files. For example if you
+/// have a CSV file and you want to ref to a certain entry in that CSV.
+///
+/// In general: If you want to refer to data in a file which contains structured data, you can
+/// create a reference to that file with `libimagentryref::reference` and a reference to the data
+/// entry with `libimagentryref::dataref`.
+///
+pub trait ContentHashGenerator {
+    type Error: From<RE>;
+
+    /// Create a content hash for the file behind the `path`
+    ///
+    /// The context information of `self` can be used to parse the file and produce the hash
+    fn create_hash<P: AsRef<Path>>(&self, path: P) -> Result<String, Self::Error>;
+}
+
 /// A extensions for the `Store` to handle `Ref` objects
 ///
 /// The RefStore handles refs using a `UniqueRefPathGenerator`. The `UniqueRefPathGenerator`, as it

--- a/lib/entry/libimagentryref/src/refstore.rs
+++ b/lib/entry/libimagentryref/src/refstore.rs
@@ -103,14 +103,31 @@ pub trait RefStore<'a> {
         where RPG: UniqueRefPathGenerator,
               H: AsRef<str>;
 
+    fn get_content_ref<RPG, H, CHG>(&'a self, hash: H, chg: &CHG)
+        -> Result<Option<FileLockEntry<'a>>, Either<RPG::Error, CHG::Error>>
+        where RPG: UniqueRefPathGenerator,
+              CHG: ContentHashGenerator,
+              H: AsRef<str>;
+
     fn create_ref<RPG, H>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>
         where RPG: UniqueRefPathGenerator,
               H: AsRef<Path>;
+
+    fn create_content_ref<RPG, CHG, A>(&'a self, path: A)
+        -> Result<FileLockEntry<'a>, Either<RPG::Error, CHG::Error>>
+        where RPG: UniqueRefPathGenerator,
+              CHG: ContentHashGenerator,
+              A: AsRef<Path>;
 
     fn retrieve_ref<RPG, A>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>
         where RPG: UniqueRefPathGenerator,
               H: AsRef<Path>;
 
+    fn retrieve_content_ref<RPG, CHG, H>(&'a self, path: A)
+        -> Result<FileLockEntry<'a>, Either<RPG::Error, CHG::Error>>
+        where RPG: UniqueRefPathGenerator,
+              CHG: ContentHashGenerator,
+              H: AsRef<Path>;
 
 }
 

--- a/lib/entry/libimagentryref/src/refstore.rs
+++ b/lib/entry/libimagentryref/src/refstore.rs
@@ -99,16 +99,26 @@ pub trait ContentHashGenerator {
 ///
 pub trait RefStore<'a> {
 
-    fn get_ref<RPG: UniqueRefPathGenerator, H: AsRef<str>>(&'a self, hash: H) -> Result<Option<FileLockEntry<'a>>, RPG::Error>;
-    fn create_ref<RPG: UniqueRefPathGenerator, A: AsRef<Path>>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>;
-    fn retrieve_ref<RPG: UniqueRefPathGenerator, A: AsRef<Path>>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>;
+    fn get_ref<RPG, H>(&'a self, hash: H) -> Result<Option<FileLockEntry<'a>>, RPG::Error>
+        where RPG: UniqueRefPathGenerator,
+              H: AsRef<str>;
+
+    fn create_ref<RPG, H>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>
+        where RPG: UniqueRefPathGenerator,
+              H: AsRef<Path>;
+
+    fn retrieve_ref<RPG, A>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>
+        where RPG: UniqueRefPathGenerator,
+              H: AsRef<Path>;
+
 
 }
 
 impl<'a> RefStore<'a> for Store {
 
-    fn get_ref<RPG: UniqueRefPathGenerator, H: AsRef<str>>(&'a self, hash: H)
-        -> Result<Option<FileLockEntry<'a>>, RPG::Error>
+    fn get_ref<RPG, H>(&'a self, hash: H) -> Result<Option<FileLockEntry<'a>>, RPG::Error>
+        where RPG: UniqueRefPathGenerator,
+              H: AsRef<str>
     {
         let sid = StoreId::new_baseless(PathBuf::from(format!("{}/{}", RPG::collection(), hash.as_ref())))
             .map_err(RE::from)?;
@@ -119,8 +129,9 @@ impl<'a> RefStore<'a> for Store {
             .map_err(RPG::Error::from)
     }
 
-    fn create_ref<RPG: UniqueRefPathGenerator, A: AsRef<Path>>(&'a self, path: A)
-        -> Result<FileLockEntry<'a>, RPG::Error>
+    fn create_ref<RPG, H>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>
+        where RPG: UniqueRefPathGenerator,
+              H: AsRef<Path>
     {
         let hash     = RPG::unique_hash(&path)?;
         let pathbuf  = PathBuf::from(format!("{}/{}", RPG::collection(), hash));
@@ -136,8 +147,9 @@ impl<'a> RefStore<'a> for Store {
             .map_err(RPG::Error::from)
     }
 
-    fn retrieve_ref<RPG: UniqueRefPathGenerator, A: AsRef<Path>>(&'a self, path: A)
-        -> Result<FileLockEntry<'a>, RPG::Error>
+    fn retrieve_ref<RPG, A>(&'a self, path: A) -> Result<FileLockEntry<'a>, RPG::Error>
+        where RPG: UniqueRefPathGenerator,
+              H: AsRef<Path>
     {
         match self.get_ref::<RPG, String>(RPG::unique_hash(path.as_ref())?)? {
             Some(r) => Ok(r),


### PR DESCRIPTION
## Problem

Right now we have the problem that we cannot refer to a single entry in a file. For example, if we have a "icalendar" file which contains 2 events, a reference points to the _file_ rather to the actual entry.

## Idea

The idea is that we create a "content ref", a reference which point to an specific "entry" inside the file.
The normal reference would be created like normal, but with the `ContentRef` we create more information.

## Implementation details

The following implementation details are not yet figured out:

### How to store

Maybe we can create a `{ref}-{content-ref}` filename from it, but this would imply that neither the "ref" nor the "content-ref" contains the seperator-character.
What would be more flexible: the "ref" part will be the directory and the "content-ref" part will be the filename.
But then we cannot create a ref to the file without any content ref (or we create "{ref}/file", but that would imply that "content-ref" can never be "file".

Maybe the way to go is:

* If there is only a "ref", we create a file at "{ref}/file"
* If there is a "ref" and a content-ref, we create a file at "{ref}/content-{content-ref}"

which would be the simplest way to go.

---

This is required for `imag-calendar` to work.