### PR TITLE
libimagrt: editor in config

### DIFF
--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -80,6 +80,8 @@ This section contains the changelog from the last release to the next release.
       `std::str::Lines` iterator takes empty lines as no lines.
     * `libimagentryedit` fixed to inherit stdin and stderr to child process for
       editor command.
+    * `libimagrt` produced the editor command without taking arguments into
+      account.
 
 
 ## 0.6.3

--- a/doc/src/09020-changelog.md
+++ b/doc/src/09020-changelog.md
@@ -57,6 +57,8 @@ This section contains the changelog from the last release to the next release.
     * `imag-diary` supports "daily" diaries now.
     * `imag-contact` joins multiple emails with "," now
     * `imag-tag` commandline was rewritten for positional arguments.
+    * `libimagrt` automatically takes "rt.editor" into account when building
+      editor object
 * Bugfixes
     * imag does not panic anymore when piping and breaking that pipe, for
       example like with `imag store ids | head -n 1`.

--- a/imagrc.toml
+++ b/imagrc.toml
@@ -1,6 +1,9 @@
 # This is a example configuration file for the imag suite.
 # It is written in TOML
 
+[rt]
+editor = "vim"
+
 #
 # imag supports templates when specifying formats. The templates support several
 # functionalities, from colorizing to underlining and such things.

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -25,6 +25,7 @@ use std::io::Stdin;
 
 pub use clap::App;
 use toml::Value;
+use toml_query::read::TomlValueReadExt;
 
 use clap::{Arg, ArgMatches};
 
@@ -457,7 +458,15 @@ impl<'a> Runtime<'a> {
         self.cli()
             .value_of("editor")
             .map(String::from)
+            .or_else(|| {
+                self.config()
+                    .and_then(|v| match v.read("rt.editor") {
+                        Ok(Some(&Value::String(ref s))) => Some(s.clone()),
+                        _ => None, // FIXME silently ignore errors in config is bad
+                    })
+            })
             .or(env::var("EDITOR").ok())
+            .map(|s| {debug!("Editing with '{}'", s); s})
             .map(|s| {
                 let mut c = Command::new(s);
                 c.stdin(::std::process::Stdio::inherit());

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -467,11 +467,17 @@ impl<'a> Runtime<'a> {
             })
             .or(env::var("EDITOR").ok())
             .map(|s| {debug!("Editing with '{}'", s); s})
-            .map(|s| {
-                let mut c = Command::new(s);
-                c.stdin(::std::process::Stdio::inherit());
+            .and_then(|s| {
+                let mut split = s.split(" ");
+                let command   = split.next();
+                if command.is_none() {
+                    return None
+                }
+                let mut c = Command::new(command.unwrap()); // secured above
+                c.args(split);
+                c.stdin(::std::process::Stdio::null());
                 c.stderr(::std::process::Stdio::inherit());
-                c
+                Some(c)
             })
     }
 


### PR DESCRIPTION
libimagrt can read the editor from the config file as well. (feature)

Contains a fix for the case where `$EDITOR` was more than one word (arguments must be passed correctly).