### PR TITLE
Fix: Use retrieve in retrieve variant

### DIFF
--- a/lib/domain/libimaghabit/src/habit.rs
+++ b/lib/domain/libimaghabit/src/habit.rs
@@ -115,7 +115,7 @@ impl HabitTemplate for Entry {
         let date    = date_to_string(date);
         let id      = instance_id_for_name_and_datestr(&name, &date)?;
 
-        store.create(id)
+        store.retrieve(id)
             .map_err(From::from)
             .and_then(|entry| postprocess_instance(entry, name, date, comment))
     }


### PR DESCRIPTION
Followup for #1357 which actually used `Store::create` in the `retrieve` variant of the interface.

I guess I was not properly awake when merging. Shame on me.