### PR TITLE
Remove "build" job to speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ script:
   - |
     bash ./scripts/find-dead-symlinks || exit 1
     bash ./scripts/license-headers-updated || exit 1
-    cargo build --all --all-features -j 1 || exit 1
     cargo test  --all --all-features -j 1 || exit 1
 
 notifications:


### PR DESCRIPTION
I'm not entirely sure, but I _think_ that actually doing `cargo test --all --all-features` is enough... we don't need to do `cargo build` as well.

Still waiting on more insight from [here](https://users.rust-lang.org/t/is-it-safe-to-do-only-cargo-test-in-my-travis-jobs/16369/3)