### PR TITLE
imag-contact: Fix formatted output, use seperator for lists

### DIFF
--- a/bin/domain/imag-contact/src/util.rs
+++ b/bin/domain/imag-contact/src/util.rs
@@ -29,7 +29,7 @@ pub fn build_data_object_for_handlebars<'a>(i: usize, hash: String, vcard: &Vcar
         data.insert("id"           , hash);
 
         data.insert("ADR"          , vcard.adr()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("ANNIVERSARY"  , vcard.anniversary()
                 .map(|c| c.raw().clone()).unwrap_or(String::new()));
@@ -38,7 +38,7 @@ pub fn build_data_object_for_handlebars<'a>(i: usize, hash: String, vcard: &Vcar
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
 
         data.insert("CATEGORIES"   , vcard.categories()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("CLIENTPIDMAP" , vcard.clientpidmap()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
@@ -47,73 +47,73 @@ pub fn build_data_object_for_handlebars<'a>(i: usize, hash: String, vcard: &Vcar
                     .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("FN"           , vcard.fullname()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("GENDER"       , vcard.gender()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
 
         data.insert("GEO"          , vcard.geo()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("IMPP"         , vcard.impp()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("KEY"          , vcard.key()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("LANG"         , vcard.lang()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("LOGO"         , vcard.logo()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("MEMBER"       , vcard.member()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("N"            , vcard.name()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
 
         data.insert("NICKNAME"     , vcard.nickname()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("NOTE"         , vcard.note()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("ORG"          , vcard.org()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("PHOTO"        , vcard.photo()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("PRIOD"        , vcard.proid()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
 
         data.insert("RELATED"      , vcard.related()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("REV"          , vcard.rev()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
 
         data.insert("ROLE"         , vcard.role()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("SOUND"        , vcard.sound()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("TEL"          , vcard.tel()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("TITLE"        , vcard.title()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("TZ"           , vcard.tz()
-                    .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("UID"          , vcard.uid()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));
 
         data.insert("URL"          , vcard.url()
-                .into_iter().map(|c| c.raw().clone()).collect());
+                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
 
         data.insert("VERSION"      , vcard.version()
                     .map(|c| c.raw().clone()).unwrap_or(String::new()));


### PR DESCRIPTION
The formatted output should use ", " as seperator for lists of values

---

Changelog pushed to `minor` branch.