### PR TITLE
Fix: Editor commands should be split at whitespace

### DIFF
--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -472,7 +472,7 @@ impl<'a> Runtime<'a> {
             .ok_or_else(|| RuntimeErrorKind::IOError.into())
             .map_dbg(|s| format!("Editing with '{}'", s))
             .and_then(|s| {
-                let mut split = s.split(" ");
+                let mut split = s.split_whitespace();
                 let command   = split.next();
                 if command.is_none() {
                     return Ok(None)


### PR DESCRIPTION
This fixes the following problem:

If the editor setting was "vim " instead of "vim", the editor was called
with `"vim" " "`, which resulted in unexpected behaviour.

The patch fixes this.