### PR TITLE
Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,36 @@ dist:
 
 language: rust
 
-rust:
-  - 1.23.0
-  - 1.24.0
-  - stable
+matrix:
+    include:
+        - language: rust
+          rust: 1.23.0
+          cache:
+            cargo: true
+          script:
+            - cargo build --all --all-features -j 1  || exit 1
+            - cargo test  --all --all-features -j 1  || exit 1
+        - language: rust
+          rust: 1.24.0
+          cache:
+            cargo: true
+          script:
+            - cargo build --all --all-features -j 1  || exit 1
+            - cargo test  --all --all-features -j 1  || exit 1
+        - language: rust
+          rust: stable
+          cache:
+            cargo: true
+          script:
+            - cargo build --all --all-features -j 1  || exit 1
+            - cargo test  --all --all-features -j 1  || exit 1
 
-cache:
-  cargo: true
 
 addons:
   apt:
     packages:
     - libdbus-1-dev
     - pkg-config
-
-script:
-  - |
-    bash ./scripts/find-dead-symlinks || exit 1
-    bash ./scripts/license-headers-updated || exit 1
-    cargo build --all --all-features -j 1 || exit 1
-    cargo test  --all --all-features -j 1 || exit 1
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ language: rust
 
 matrix:
     include:
+        - language: nix
+          script:
+            - bash ./scripts/find-dead-symlinks
+            - bash ./scripts/license-headers-updated
+            - bash ./scripts/branch-contains-no-tmp-commits
         - language: rust
           rust: 1.23.0
           cache:

--- a/scripts/branch-contains-no-tmp-commits
+++ b/scripts/branch-contains-no-tmp-commits
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+COMMIT_RANGE=""
+
+if [[ $TRAVIS ]]; then
+    if [[ -z "$TRAVIS_COMMIT_RANGE" ]]; then
+        COMMIT_RANGE=HEAD^..HEAD
+    else
+        COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
+    fi
+else
+    COMMIT_RANGE=$(git merge-base master  HEAD)..HEAD
+fi
+
+logfreeof() {
+    git log --format="%s" $COMMIT_RANGE |\
+        awk '{print $1}' |\
+        grep -i "$1" && echo "LOG CONTAINS '$1'" && exit 1
+
+    return 0
+}
+
+logfreeof "fixup"
+logfreeof "squash"
+logfreeof "wip"
+logfreeof "tmp"
+logfreeof "ci skip"
+

--- a/scripts/mkdocset
+++ b/scripts/mkdocset
@@ -6,7 +6,7 @@ CARGO=$(which cargo || exit 1)
 RSDOCSDASHING=$(which rsdocs-dashing || exit 1)
 DASHING=$(which dashing || exit 1)
 
-$CARGO doc --all || exit 1
+find lib -name "Cargo.toml" -exec $CARGO doc --manifest-path {} \; || exit 1
 
 ls target/doc | grep imag | while read pkg; do
     $RSDOCSDASHING target/doc/$pkg docset-$pkg

--- a/scripts/mkdocset
+++ b/scripts/mkdocset
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# execute from repository root
+
+CARGO=$(which cargo || exit 1)
+RSDOCSDASHING=$(which rsdocs-dashing || exit 1)
+DASHING=$(which dashing || exit 1)
+
+$CARGO doc --all || exit 1
+
+ls target/doc | grep imag | while read pkg; do
+    $RSDOCSDASHING target/doc/$pkg docset-$pkg
+    $DASHING build --config docset-$pkg/dashing.json --source docset-$pkg/build
+done
+
+


### PR DESCRIPTION
Change the travis setup to use the build matrix.

This includes a new job which does the scripted tests (are the license headers in place, are there dead symlinks).

This branch also contains a new script for creating (dash/zeal) docsets from the source.