### PR TITLE
Fix: Pass the right path variable here

### DIFF
--- a/lib/entry/libimagentryref/src/refstore.rs
+++ b/lib/entry/libimagentryref/src/refstore.rs
@@ -103,7 +103,7 @@ impl<'a> RefStore<'a> for Store {
     fn create_ref<RPG: UniqueRefPathGenerator, A: AsRef<Path>>(&'a self, path: A)
         -> Result<FileLockEntry<'a>, RPG::Error>
     {
-        let hash     = RPG::unique_hash(path)?;
+        let hash     = RPG::unique_hash(&path)?;
         let pathbuf  = PathBuf::from(format!("{}/{}", RPG::collection(), hash));
         let sid      = StoreId::new_baseless(pathbuf.clone()).map_err(RE::from)?;
 
@@ -111,7 +111,7 @@ impl<'a> RefStore<'a> for Store {
         self.create(sid)
             .map_err(RE::from)
             .and_then(|mut fle| {
-                fle.make_ref(hash, pathbuf)?;
+                fle.make_ref(hash, path)?;
                 Ok(fle)
             })
             .map_err(RPG::Error::from)


### PR DESCRIPTION
The ref library passed the wrong variable as path which caused the
setting in the entries to be wrong.

This patch fixes this.

Closes #1389 