### PR TITLE
Remove attribute (fix for beta compiler)

### DIFF
--- a/lib/entry/libimagentrylink/src/internal.rs
+++ b/lib/entry/libimagentrylink/src/internal.rs
@@ -700,7 +700,6 @@ pub mod store_check {
             };
 
             // Helper function to create a SLCECD::OneDirectionalLink error object
-            #[inline]
             let mk_one_directional_link_err = |src: StoreId, target: StoreId| -> LE {
                 LE::from_kind(LEK::DeadLink(src, target))
             };


### PR DESCRIPTION
This fixes a crash with the (beta) compiler rustc 1.26.

---

As reported via https://github.com/rust-lang/rust/issues/49934