### PR TITLE
Fix log level setting in runtime

### DIFF
--- a/lib/core/libimagrt/src/logger.rs
+++ b/lib/core/libimagrt/src/logger.rs
@@ -231,13 +231,13 @@ fn aggregate_global_loglevel(matches: &ArgMatches, config: Option<&Value>) -> Re
             return Ok(Some(Level::Debug))
         }
 
-        if matches.is_present(Runtime::arg_verbosity_name()) {
-            return Ok(Some(Level::Info))
-        }
-
         match matches.value_of(Runtime::arg_verbosity_name()) {
             Some(v) => match_log_level_str(v).map(Some),
-            None    => Ok(None),
+            None    => if matches.is_present(Runtime::arg_verbosity_name()) {
+                Ok(Some(Level::Info))
+            } else {
+                Ok(None)
+            },
         }
     }
 

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -185,6 +185,7 @@ impl<'a> Runtime<'a> {
                 .required(false)
                 .takes_value(true)
                 .possible_values(&["trace", "debug", "info", "warn", "error"])
+                .default_value("info")
                 .value_name("LOGLEVEL"))
 
             .arg(Arg::with_name(Runtime::arg_debugging_name())


### PR DESCRIPTION
Do not immediately set log level to Level::Info if argument is present,
but check value, too.