### PR TITLE
Revert "Implement pipe magic in libimagrt"

### DIFF
--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -52,7 +52,6 @@ pub struct Runtime<'a> {
     configuration: Option<Value>,
     cli_matches: ArgMatches<'a>,
     store: Store,
-    use_pipe_magic: bool,
     stdin_is_tty: bool,
     stdout_is_tty: bool,
 }
@@ -139,15 +138,12 @@ impl<'a> Runtime<'a> {
             Store::new(storepath, &config)
         };
 
-        let pipe_magic = matches.is_present(Runtime::pipe_magic_name());
-
         store_result.map(|store| {
             Runtime {
                 cli_matches: matches,
                 configuration: config,
                 rtp: rtp,
                 store: store,
-                use_pipe_magic: pipe_magic,
                 stdout_is_tty: ::atty::is(::atty::Stream::Stdout),
                 stdin_is_tty: ::atty::is(::atty::Stream::Stdin),
             }
@@ -236,13 +232,6 @@ impl<'a> Runtime<'a> {
                 .takes_value(true)
                 .value_name("LOGDESTS"))
 
-            .arg(Arg::with_name(Runtime::pipe_magic_name())
-                .long(Runtime::pipe_magic_name())
-                .short("P")
-                .help("Use pipe-detection. With this flag, imag expects a JSON store on STDIN if stdin is not a TTY and prints the store to STDOUT if it is not a TTY.")
-                .required(false)
-                .takes_value(false))
-
     }
 
     /// Get the argument names of the Runtime which are available
@@ -325,11 +314,6 @@ impl<'a> Runtime<'a> {
     /// Get the argument name for the logging destination
     pub fn arg_logdest_name() -> &'static str {
         "logging-destinations"
-    }
-
-    /// Get the argument name for pipe magic
-    pub fn pipe_magic_name() -> &'static str {
-        "pipe-magic"
     }
 
     /// Initialize the internal logger
@@ -460,10 +444,10 @@ impl<'a> Runtime<'a> {
     }
 
     pub fn stdout(&self) -> OutputProxy {
-        if self.use_pipe_magic && !self.stdout_is_tty {
-            OutputProxy::Err(::std::io::stderr())
-        } else {
+        if self.stdout_is_tty {
             OutputProxy::Out(::std::io::stdout())
+        } else {
+            OutputProxy::Err(::std::io::stderr())
         }
     }
 
@@ -472,10 +456,10 @@ impl<'a> Runtime<'a> {
     }
 
     pub fn stdin(&self) -> Option<Stdin> {
-        if self.use_pipe_magic && !self.stdin_is_tty {
-            None
-        } else {
+        if self.stdin_is_tty {
             Some(::std::io::stdin())
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
This reverts commit ce0bd9298addfbb9f167ddd06bd2c781eb3de8c0.

Pipe magic is removed with this patch.

We remove pipe magic because its implementation in libimagstore is too
complicated and the benefits are too small.
Having this functionality would be really nice, but the cost-benefit
ratio would still be too high.
The implementation in the store would require a rewrite of the internal
caching functionality in the store, plus some functionality to serialize
and deserialize the cache. This is theoretically possible, but as the
store only knows about "StoreEntry" objects, and only the backend knows
of "Entry" (which would be simply de/serializeable), the complexity
increases a _lot_.

Hence, we drop this feature-idea here.

Maybe, at some later point, this functionality will be in imag. The
history of development of this feature is in the history, we just don't
have it merged.

Signed-off-by: Matthias Beyer <mail@beyermatthias.de>