### PR TITLE
Make stdin always available

### DIFF
--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -457,11 +457,7 @@ impl<'a> Runtime<'a> {
     }
 
     pub fn stdin(&self) -> Option<Stdin> {
-        if self.stdin_is_tty {
-            Some(::std::io::stdin())
-        } else {
-            None
-        }
+        Some(::std::io::stdin())
     }
 
     /// Helper for handling subcommands which are not available.

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -52,8 +52,6 @@ pub struct Runtime<'a> {
     configuration: Option<Value>,
     cli_matches: ArgMatches<'a>,
     store: Store,
-    stdin_is_tty: bool,
-    stdout_is_tty: bool,
 }
 
 impl<'a> Runtime<'a> {
@@ -144,8 +142,6 @@ impl<'a> Runtime<'a> {
                 configuration: config,
                 rtp: rtp,
                 store: store,
-                stdout_is_tty: ::atty::is(::atty::Stream::Stdout),
-                stdin_is_tty: ::atty::is(::atty::Stream::Stdin),
             }
         })
         .chain_err(|| RuntimeErrorKind::Instantiate)
@@ -445,11 +441,7 @@ impl<'a> Runtime<'a> {
     }
 
     pub fn stdout(&self) -> OutputProxy {
-        if self.stdout_is_tty {
-            OutputProxy::Out(::std::io::stdout())
-        } else {
-            OutputProxy::Err(::std::io::stderr())
-        }
+        OutputProxy::Out(::std::io::stdout())
     }
 
     pub fn stderr(&self) -> OutputProxy {


### PR DESCRIPTION
Because we do not implement the store piping and pipe magic, the stdin
stream should always be available.