### PR TITLE
Rewrite libimagentryview interface

### DIFF
--- a/bin/core/imag-view/src/main.rs
+++ b/bin/core/imag-view/src/main.rs
@@ -185,6 +185,9 @@ fn main() {
             viewer.wrap_at(width);
         }
 
+        let output      = rt.stdout();
+        let mut lockout = output.lock();
+
         entry_ids
             .into_iter()
             .into_get_iter(rt.store())
@@ -195,7 +198,7 @@ fn main() {
                      .map_err_trace_exit_unwrap(1)
             })
             .for_each(|e| {
-                viewer.view_entry(&e).map_err_trace_exit_unwrap(1);
+                viewer.view_entry(&e, &mut lockout).map_err_trace_exit_unwrap(1);
             });
     }
 }

--- a/bin/domain/imag-diary/Cargo.toml
+++ b/bin/domain/imag-diary/Cargo.toml
@@ -33,6 +33,7 @@ libimagstore       = { version = "0.8.0", path = "../../../lib/core/libimagstore
 libimagrt          = { version = "0.8.0", path = "../../../lib/core/libimagrt" }
 libimagdiary       = { version = "0.8.0", path = "../../../lib/domain/libimagdiary" }
 libimagentryedit   = { version = "0.8.0", path = "../../../lib/entry/libimagentryedit" }
+libimagentryview   = { version = "0.8.0", path = "../../../lib/entry/libimagentryview" }
 libimaginteraction = { version = "0.8.0", path = "../../../lib/etc/libimaginteraction" }
 libimagutil        = { version = "0.8.0", path = "../../../lib/etc/libimagutil" }
 libimagtimeui      = { version = "0.8.0", path = "../../../lib/etc/libimagtimeui" }

--- a/bin/domain/imag-diary/src/main.rs
+++ b/bin/domain/imag-diary/src/main.rs
@@ -41,6 +41,7 @@ extern crate itertools;
 
 extern crate libimagdiary;
 extern crate libimagentryedit;
+extern crate libimagentryview;
 extern crate libimagerror;
 extern crate libimaginteraction;
 #[macro_use] extern crate libimagrt;

--- a/bin/domain/imag-diary/src/view.rs
+++ b/bin/domain/imag-diary/src/view.rs
@@ -23,6 +23,7 @@ use libimagrt::runtime::Runtime;
 use libimagerror::trace::MapErrTrace;
 use libimagutil::warn_exit::warn_exit;
 use libimagstore::iter::get::StoreIdGetIteratorExtension;
+use libimagentryview::viewer::Viewer;
 
 use util::get_diary_name;
 
@@ -39,7 +40,8 @@ pub fn view(rt: &Runtime) {
             ::std::process::exit(1)
         }));
 
-    DV::new(hdr).view_entries(entries)
+    let out = rt.stdout();
+    DV::new(hdr).view_entries(entries, &mut out.lock())
         .map_err_trace_exit_unwrap(1);
 }
 

--- a/lib/domain/libimagdiary/src/error.rs
+++ b/lib/domain/libimagdiary/src/error.rs
@@ -22,6 +22,10 @@ error_chain! {
         DiaryError, DiaryErrorKind, ResultExt, Result;
     }
 
+    foreign_links {
+        Io(::std::io::Error);
+    }
+
     links {
         StoreError(::libimagstore::error::StoreError, ::libimagstore::error::StoreErrorKind);
         EntryUtilError(::libimagentryutil::error::EntryUtilError, ::libimagentryutil::error::EntryUtilErrorKind);

--- a/lib/entry/libimagentryview/src/builtin/editor.rs
+++ b/lib/entry/libimagentryview/src/builtin/editor.rs
@@ -17,6 +17,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+use std::io::Write;
+
 use libimagstore::store::Entry;
 use libimagrt::runtime::Runtime;
 use libimagentryedit::edit::edit_in_tmpfile;
@@ -35,7 +37,9 @@ impl<'a> EditorView<'a> {
 }
 
 impl<'a> Viewer for EditorView<'a> {
-    fn view_entry(&self, e: &Entry) -> Result<()> {
+    fn view_entry<W>(&self, e: &Entry, _sink: &mut W) -> Result<()>
+        where W: Write
+    {
         let mut entry = e.to_str()?.clone().to_string();
         edit_in_tmpfile(self.0, &mut entry).chain_err(|| VEK::ViewError)
     }

--- a/lib/entry/libimagentryview/src/builtin/plain.rs
+++ b/lib/entry/libimagentryview/src/builtin/plain.rs
@@ -17,6 +17,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+use std::io::Write;
+
 use libimagstore::store::Entry;
 
 use viewer::Viewer;
@@ -38,11 +40,13 @@ impl PlainViewer {
 
 impl Viewer for PlainViewer {
 
-    fn view_entry(&self, e: &Entry) -> Result<()> {
+    fn view_entry<W>(&self, e: &Entry, sink: &mut W) -> Result<()>
+        where W: Write
+    {
         if self.show_header {
-            println!("{}", e.get_header());
+            let _ = writeln!(sink, "{}", e.get_header())?;
         }
-        println!("{}", e.get_content());
+        let _ = writeln!(sink, "{}", e.get_content())?;
         Ok(())
     }
 

--- a/lib/entry/libimagentryview/src/error.rs
+++ b/lib/entry/libimagentryview/src/error.rs
@@ -22,6 +22,10 @@ error_chain! {
         ViewError, ViewErrorKind, ResultExt, Result;
     }
 
+    foreign_links {
+        IO(::std::io::Error);
+    }
+
     links {
         StoreError(::libimagstore::error::StoreError, ::libimagstore::error::StoreErrorKind);
     }

--- a/lib/entry/libimagentryview/src/viewer.rs
+++ b/lib/entry/libimagentryview/src/viewer.rs
@@ -17,17 +17,25 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+use std::io::Write;
+use std::ops::Deref;
+
 use libimagstore::store::Entry;
 
 use error::Result;
 
 pub trait Viewer {
 
-    fn view_entry(&self, e: &Entry) -> Result<()>;
+    fn view_entry<W>(&self, e: &Entry, sink: &mut W) -> Result<()>
+        where W: Write;
 
-    fn view_entries<I: Iterator<Item = Entry>>(&self, entries: I) -> Result<()> {
+    fn view_entries<I, E, W>(&self, entries: I, sink: &mut W) -> Result<()>
+        where I: Iterator<Item = E>,
+              E: Deref<Target = Entry>,
+              W: Write
+    {
         for entry in entries {
-            if let Err(e) = self.view_entry(&entry) {
+            if let Err(e) = self.view_entry(entry.deref(), sink) {
                 return Err(e);
             }
         }


### PR DESCRIPTION
In the previous versions, the sink (where the entries should be written
to) was not passed.

This did conflict with the libimagrt holding the stdout/stderr handles,
because it automatically writes to stdout (which we don't want to do in
some cases).

Passing the sink is way nicer. This patch changes libimagentryview so
that the sink is passed to the viewer.

---

Closes #1390 