### PR TITLE
Do not depend on "version" crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
             - bash ./scripts/find-dead-symlinks
             - bash ./scripts/license-headers-updated
             - bash ./scripts/branch-contains-no-tmp-commits
+            - bash ./scripts/version-updated
         - language: rust
           rust: 1.23.0
           cache:

--- a/bin/core/imag/Cargo.toml
+++ b/bin/core/imag/Cargo.toml
@@ -17,7 +17,6 @@ build = "build.rs"
 
 [build-dependencies]
 clap = ">=2.16.1"
-version = "2.0"
 libimagrt       = { version = "0.8.0", path = "../../../lib/core/libimagrt" }
 libimagentrytag = { version = "0.8.0", path = "../../../lib/entry/libimagentrytag" }
 libimagutil     = { version = "0.8.0", path = "../../../lib/etc/libimagutil" }

--- a/bin/core/imag/build.rs
+++ b/bin/core/imag/build.rs
@@ -18,10 +18,10 @@
 //
 
 extern crate clap;
+#[macro_use]
 extern crate libimagrt;
 extern crate libimagentrytag;
 extern crate libimagutil;
-#[macro_use] extern crate version;
 
 use clap::Shell;
 use libimagrt::runtime::Runtime;
@@ -67,8 +67,8 @@ macro_rules! gen_mods_buildui {
 /// output of this script is a completion script, which
 /// does not contain information about the version at all.
 macro_rules! build_subcommand {
-    ($name:expr, $module:ident) => (
-        $module::build_ui(Runtime::get_default_cli_builder($name, &version!()[..], $name))
+    ($name:expr, $module:ident, $version:ident) => (
+        $module::build_ui(Runtime::get_default_cli_builder($name, &$version, $name))
     )
 }
 
@@ -100,33 +100,34 @@ gen_mods_buildui!(
 
 fn main() {
     // Make the `imag`-App...
+    let version = make_imag_version!();
     let mut app = Runtime::get_default_cli_builder(
         "imag",
-        &version!()[..],
+        &version[..],
         "imag")
         // and add all the subapps as subcommands.
-        .subcommand(build_subcommand!("annotate",    imagannotate))
-        .subcommand(build_subcommand!("diagnostics", imagdiagnostics))
-        .subcommand(build_subcommand!("edit",        imagedit))
-        .subcommand(build_subcommand!("gps",         imaggps))
-        .subcommand(build_subcommand!("grep",        imaggrep))
-        .subcommand(build_subcommand!("ids",         imagids))
-        .subcommand(build_subcommand!("init",        imaginit))
-        .subcommand(build_subcommand!("link",        imaglink))
-        .subcommand(build_subcommand!("mv",          imagmv))
-        .subcommand(build_subcommand!("ref",         imagref))
-        .subcommand(build_subcommand!("store",       imagstore))
-        .subcommand(build_subcommand!("tag",         imagtag))
-        .subcommand(build_subcommand!("view",        imagview))
-        .subcommand(build_subcommand!("bookmark",    imagbookmark))
-        .subcommand(build_subcommand!("contact",     imagcontact))
-        .subcommand(build_subcommand!("diary",       imagdiary))
-        .subcommand(build_subcommand!("habit",       imaghabit))
-        .subcommand(build_subcommand!("log",         imaglog))
-        .subcommand(build_subcommand!("mail",        imagmail))
-        .subcommand(build_subcommand!("notes",       imagnotes))
-        .subcommand(build_subcommand!("timetrack",   imagtimetrack))
-        .subcommand(build_subcommand!("todo",        imagtodo));
+        .subcommand(build_subcommand!("annotate",    imagannotate,      version))
+        .subcommand(build_subcommand!("diagnostics", imagdiagnostics,   version))
+        .subcommand(build_subcommand!("edit",        imagedit,          version))
+        .subcommand(build_subcommand!("gps",         imaggps,           version))
+        .subcommand(build_subcommand!("grep",        imaggrep,          version))
+        .subcommand(build_subcommand!("ids",         imagids,           version))
+        .subcommand(build_subcommand!("init",        imaginit,          version))
+        .subcommand(build_subcommand!("link",        imaglink,          version))
+        .subcommand(build_subcommand!("mv",          imagmv,            version))
+        .subcommand(build_subcommand!("ref",         imagref,           version))
+        .subcommand(build_subcommand!("store",       imagstore,         version))
+        .subcommand(build_subcommand!("tag",         imagtag,           version))
+        .subcommand(build_subcommand!("view",        imagview,          version))
+        .subcommand(build_subcommand!("bookmark",    imagbookmark,      version))
+        .subcommand(build_subcommand!("contact",     imagcontact,       version))
+        .subcommand(build_subcommand!("diary",       imagdiary,         version))
+        .subcommand(build_subcommand!("habit",       imaghabit,         version))
+        .subcommand(build_subcommand!("log",         imaglog,           version))
+        .subcommand(build_subcommand!("mail",        imagmail,          version))
+        .subcommand(build_subcommand!("notes",       imagnotes,         version))
+        .subcommand(build_subcommand!("timetrack",   imagtimetrack,     version))
+        .subcommand(build_subcommand!("todo",        imagtodo,          version));
 
     // Actually generates the completion files
     app.gen_completions("imag", Shell::Bash, "../../../target/");

--- a/bin/domain/imag-wiki/Cargo.toml
+++ b/bin/domain/imag-wiki/Cargo.toml
@@ -21,7 +21,6 @@ log = "0.3"
 toml = "0.4"
 toml-query = "0.6"
 is-match = "0.1"
-version = "2.0.1"
 regex = "0.2"
 filters = "0.2"
 

--- a/lib/core/libimagrt/src/version.rs
+++ b/lib/core/libimagrt/src/version.rs
@@ -20,13 +20,18 @@
 #[macro_export]
 macro_rules! make_imag_version {
     () => {{
-        let pkg_version = env!("CARGO_PKG_VERSION");
-        let git_version = env!("CARGO_BUILD_VERSION");
+        let pkg_version = option_env!("CARGO_PKG_VERSION");
+        let git_version = option_env!("CARGO_BUILD_VERSION");
 
-        if git_version == "" {
-            String::from(pkg_version)
-        } else {
-            String::from(git_version)
+        match (git_version, pkg_version) {
+            (Some(git_version), Some(pkg_version)) => if git_version == "" {
+                String::from(pkg_version)
+            } else {
+                String::from(git_version)
+            },
+
+            // imag is not beeing build with cargo... we have to set it by hand here.
+            _ => String::from("0.8.0"),
         }
     }}
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+echo "Are you sure that the files"
+echo " * 'lib/core/libimagrt/src/version.rs'"
+echo " * 'scripts/version-updated'"
+echo "contain the right version setting?"
+echo "If yes, pass '--I-AM-SURE-VERSION-IS-UPDATED' as parameter"
+
+[[ "--I-AM-SURE-VERSION-IS-UPDATED" == $1 ]] || exit 1
 
 CRATES=(
     ./lib/etc/libimagutil

--- a/scripts/version-updated
+++ b/scripts/version-updated
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Script has to be executed from the repository root directory.
+
+version=$(grep version bin/core/imag/Cargo.toml | head -n 1 | sed 's,.*=\ ",,; s,"$,,')
+
+grep "String::from(\"${version}\")" lib/core/libimagrt/src/version.rs 2>/dev/null >/dev/null || \
+{
+    >&2 echo "No/incorrect version in lib/core/libimagrt/src/version.rs"
+    exit 1
+}
+


### PR DESCRIPTION
We should not depend on the version crate, as it is GPL licensed.

We removed the usage of this crate before, but it was still in the
Cargo.toml files (despite being used in the source).