### PR TITLE
Fix: get_youngest_entry_id()

### DIFF
--- a/lib/domain/libimagdiary/src/diary.rs
+++ b/lib/domain/libimagdiary/src/diary.rs
@@ -125,6 +125,7 @@ impl Diary for Store {
                         }
                     })
                     .into_iter()
+                    .rev()
                     //.map(|sidres| sidres.map(|sid| DiaryId::from_storeid(&sid)))
                     .next()
             }


### PR DESCRIPTION
We need to reverse the iterator for getting the _youngest_ entry here.

Also seems to fix the issue that imag-diary edit -d <date> did not work
properly.

---

Closes #1427 