### PR TITLE
Fix: Do not inherit stdout here

### DIFF
--- a/bin/core/imag/src/main.rs
+++ b/bin/core/imag/src/main.rs
@@ -221,7 +221,7 @@ fn main() {
             .map(|command| {
                 match Command::new(format!("imag-{}", command))
                     .stdin(::std::process::Stdio::inherit())
-                    .stdout(::std::process::Stdio::inherit())
+                    .stdout(::std::process::Stdio::piped())
                     .stderr(::std::process::Stdio::inherit())
                     .arg("--version")
                     .output()


### PR DESCRIPTION
This caused us to print funny output. But we want to catch the output
and print a nice list ourselves here.

---

Closes #1432 