### PR TITLE
libimagcontact: not based on libimagentryref

### DIFF
--- a/bin/domain/imag-contact/Cargo.toml
+++ b/bin/domain/imag-contact/Cargo.toml
@@ -38,12 +38,7 @@ libimagutil        = { version = "0.8.0", path = "../../../lib/etc/libimagutil" 
 libimagentryref    = { version = "0.8.0", path = "../../../lib/entry/libimagentryref" }
 libimagentryedit   = { version = "0.8.0", path = "../../../lib/entry/libimagentryedit" }
 libimaginteraction = { version = "0.8.0", path = "../../../lib/etc/libimaginteraction" }
-
-[dependencies.libimagcontact]
-version          = "0.8.0"
-path             = "../../../lib/domain/libimagcontact"
-default-features = false
-features         = ["deser"]
+libimagcontact     = { version = "0.8.0", path = "../../../lib/domain/libimagcontact" }
 
 [dependencies.clap]
 version = "^2.29"

--- a/bin/domain/imag-contact/src/create.rs
+++ b/bin/domain/imag-contact/src/create.rs
@@ -44,14 +44,13 @@ use toml_query::read::TomlValueReadExt;
 use toml::Value;
 use uuid::Uuid;
 
+use libimagcontact::store::ContactStore;
 use libimagcontact::error::ContactError as CE;
-use libimagcontact::store::UniqueContactPathGenerator;
 use libimagrt::runtime::Runtime;
 use libimagerror::str::ErrFromStr;
 use libimagerror::trace::MapErrTrace;
 use libimagerror::trace::trace_error;
 use libimagutil::warn_result::WarnResult;
-use libimagentryref::refstore::RefStore;
 
 const TEMPLATE : &'static str = include_str!("../static/new-contact-template.toml");
 
@@ -158,7 +157,8 @@ pub fn create(rt: &Runtime) {
 
     if let Some(location) = location {
         if !scmd.is_present("dont-track") {
-            RefStore::create_ref::<UniqueContactPathGenerator, _>(rt.store(), location)
+            rt.store()
+                .create_from_path(&location)
                 .map_err_trace_exit_unwrap(1);
 
             info!("Created entry in store");

--- a/bin/domain/imag-contact/src/util.rs
+++ b/bin/domain/imag-contact/src/util.rs
@@ -18,105 +18,58 @@
 //
 
 use std::collections::BTreeMap;
-use vobject::vcard::Vcard;
 
-pub fn build_data_object_for_handlebars<'a>(i: usize, hash: String, vcard: &Vcard) -> BTreeMap<&'static str, String> {
+use libimagcontact::deser::DeserVcard;
+
+pub fn build_data_object_for_handlebars<'a>(i: usize, vcard: &DeserVcard) -> BTreeMap<&'static str, String> {
     let mut data = BTreeMap::new();
+
+    let process_list = |list: &Vec<String>| {
+        list.iter()
+            .map(String::clone)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let process_opt  = |opt: Option<&String>| {
+        opt.map(String::clone).unwrap_or_else(String::new)
+    };
+
     {
         data.insert("i"            , format!("{}", i));
 
         // The hash (as in libimagentryref) of the contact
-        data.insert("id"           , hash);
-
-        data.insert("ADR"          , vcard.adr()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("ANNIVERSARY"  , vcard.anniversary()
-                .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("BDAY"         , vcard.bday()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("CATEGORIES"   , vcard.categories()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("CLIENTPIDMAP" , vcard.clientpidmap()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("EMAIL"        , vcard.email()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("FN"           , vcard.fullname()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("GENDER"       , vcard.gender()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("GEO"          , vcard.geo()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("IMPP"         , vcard.impp()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("KEY"          , vcard.key()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("LANG"         , vcard.lang()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("LOGO"         , vcard.logo()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("MEMBER"       , vcard.member()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("N"            , vcard.name()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("NICKNAME"     , vcard.nickname()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("NOTE"         , vcard.note()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("ORG"          , vcard.org()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("PHOTO"        , vcard.photo()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("PRIOD"        , vcard.proid()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("RELATED"      , vcard.related()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("REV"          , vcard.rev()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("ROLE"         , vcard.role()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("SOUND"        , vcard.sound()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("TEL"          , vcard.tel()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("TITLE"        , vcard.title()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("TZ"           , vcard.tz()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("UID"          , vcard.uid()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
-
-        data.insert("URL"          , vcard.url()
-                    .into_iter().map(|c| c.raw().clone()).collect::<Vec<_>>().join(", "));
-
-        data.insert("VERSION"      , vcard.version()
-                    .map(|c| c.raw().clone()).unwrap_or(String::new()));
+        data.insert("id"           , process_opt(vcard.uid()));
+        data.insert("ADR"          , process_list(vcard.adr()));
+        data.insert("ANNIVERSARY"  , process_opt(vcard.anniversary()));
+        data.insert("BDAY"         , process_opt(vcard.bday()));
+        data.insert("CATEGORIES"   , process_list(vcard.categories()));
+        data.insert("CLIENTPIDMAP" , process_opt(vcard.clientpidmap()));
+        data.insert("EMAIL"        , process_list(vcard.email()));
+        data.insert("FN"           , process_list(vcard.fullname()));
+        data.insert("GENDER"       , process_opt(vcard.gender()));
+        data.insert("GEO"          , process_list(vcard.geo()));
+        data.insert("IMPP"         , process_list(vcard.impp()));
+        data.insert("KEY"          , process_list(vcard.key()));
+        data.insert("LANG"         , process_list(vcard.lang()));
+        data.insert("LOGO"         , process_list(vcard.logo()));
+        data.insert("MEMBER"       , process_list(vcard.member()));
+        data.insert("N"            , process_opt(vcard.name()));
+        data.insert("NICKNAME"     , process_list(vcard.nickname()));
+        data.insert("NOTE"         , process_list(vcard.note()));
+        data.insert("ORG"          , process_list(vcard.org()));
+        data.insert("PHOTO"        , process_list(vcard.photo()));
+        data.insert("PRIOD"        , process_opt(vcard.proid()));
+        data.insert("RELATED"      , process_list(vcard.related()));
+        data.insert("REV"          , process_opt(vcard.rev()));
+        data.insert("ROLE"         , process_list(vcard.role()));
+        data.insert("SOUND"        , process_list(vcard.sound()));
+        data.insert("TEL"          , process_list(vcard.tel()));
+        data.insert("TITLE"        , process_list(vcard.title()));
+        data.insert("TZ"           , process_list(vcard.tz()));
+        data.insert("UID"          , process_opt(vcard.uid()));
+        data.insert("URL"          , process_list(vcard.url()));
+        data.insert("VERSION"      , process_opt(vcard.version()));
     }
 
     data

--- a/lib/domain/libimagcontact/Cargo.toml
+++ b/lib/domain/libimagcontact/Cargo.toml
@@ -25,15 +25,11 @@ log          = "0.3"
 toml         = "0.4"
 toml-query   = "0.6"
 vobject      = "0.4"
-uuid         = { version = "0.6", features = ["v4"] }
-serde        = { version = "1", optional   = true }
-serde_derive = { version = "1", optional   = true }
+uuid         = "0.6"
+serde        = "1"
+serde_derive = "1"
 
 libimagstore     = { version = "0.8.0", path = "../../../lib/core/libimagstore" }
 libimagerror     = { version = "0.8.0", path = "../../../lib/core/libimagerror" }
 libimagentryutil  = { version = "0.8.0", path = "../../../lib/entry/libimagentryutil/" }
-
-[features]
-default = []
-deser   = ["serde", "serde_derive"]
 

--- a/lib/domain/libimagcontact/Cargo.toml
+++ b/lib/domain/libimagcontact/Cargo.toml
@@ -33,12 +33,6 @@ libimagstore     = { version = "0.8.0", path = "../../../lib/core/libimagstore" 
 libimagerror     = { version = "0.8.0", path = "../../../lib/core/libimagerror" }
 libimagentryutil  = { version = "0.8.0", path = "../../../lib/entry/libimagentryutil/" }
 
-[dependencies.libimagentryref]
-version          = "0.8.0"
-path             = "../../../lib/entry/libimagentryref/"
-default-features = false
-features         = ["generators", "generators-sha1"]
-
 [features]
 default = []
 deser   = ["serde", "serde_derive"]

--- a/lib/domain/libimagcontact/src/contact.rs
+++ b/lib/domain/libimagcontact/src/contact.rs
@@ -22,7 +22,6 @@ use std::ops::Deref;
 use vobject::Component;
 
 use libimagstore::store::Entry;
-use libimagentryref::reference::Ref;
 use libimagentryutil::isa::Is;
 use libimagentryutil::isa::IsKindHeaderPathProvider;
 
@@ -30,9 +29,7 @@ use error::Result;
 use util;
 
 /// Trait to be implemented on ::libimagstore::store::Entry
-///
-/// Based on the functionality from libimagentryref, for fetching the Ical data from disk
-pub trait Contact : Ref {
+pub trait Contact {
 
     fn is_contact(&self) -> Result<bool>;
 
@@ -53,13 +50,7 @@ impl Contact for Entry {
     }
 
     fn get_contact_data(&self) -> Result<ContactData> {
-        let component = self
-            .get_path()
-            .map_err(From::from)
-            .and_then(util::read_to_string)
-            .and_then(util::parse)?;
-
-        Ok(ContactData(component))
+        unimplemented!()
     }
 
 }

--- a/lib/domain/libimagcontact/src/deser.rs
+++ b/lib/domain/libimagcontact/src/deser.rs
@@ -20,13 +20,7 @@
 use vobject::vcard::Vcard;
 
 /// A type which can be build from a Vcard and be serialized.
-///
-/// # Details
-///
-/// Deserializing is not supported by libimagcontact yet
-/// Elements which are "empty" (as in empty list) or optional and not present are not serialized.
-///
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DeserVcard {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/lib/domain/libimagcontact/src/deser.rs
+++ b/lib/domain/libimagcontact/src/deser.rs
@@ -162,3 +162,127 @@ impl From<Vcard> for DeserVcard {
     }
 }
 
+impl DeserVcard {
+
+    pub fn adr(&self) -> &Vec<String> {
+        &self.adr
+    }
+
+    pub fn anniversary(&self) -> Option<&String> {
+        self.anniversary.as_ref()
+    }
+
+    pub fn bday(&self) -> Option<&String> {
+        self.bday.as_ref()
+    }
+
+    pub fn categories(&self) -> &Vec<String> {
+        &self.categories
+    }
+
+    pub fn clientpidmap(&self) -> Option<&String> {
+        self.clientpidmap.as_ref()
+    }
+
+    pub fn email(&self) -> &Vec<String> {
+        &self.email
+    }
+
+    pub fn fullname(&self) -> &Vec<String> {
+        &self.fullname
+    }
+
+    pub fn gender(&self) -> Option<&String> {
+        self.gender.as_ref()
+    }
+
+    pub fn geo(&self) -> &Vec<String> {
+        &self.geo
+    }
+
+    pub fn impp(&self) -> &Vec<String> {
+        &self.impp
+    }
+
+    pub fn key(&self) -> &Vec<String> {
+        &self.key
+    }
+
+    pub fn lang(&self) -> &Vec<String> {
+        &self.lang
+    }
+
+    pub fn logo(&self) -> &Vec<String> {
+        &self.logo
+    }
+
+    pub fn member(&self) -> &Vec<String> {
+        &self.member
+    }
+
+    pub fn name(&self) -> Option<&String> {
+        self.name.as_ref()
+    }
+
+    pub fn nickname(&self) -> &Vec<String> {
+        &self.nickname
+    }
+
+    pub fn note(&self) -> &Vec<String> {
+        &self.note
+    }
+
+    pub fn org(&self) -> &Vec<String> {
+        &self.org
+    }
+
+    pub fn photo(&self) -> &Vec<String> {
+        &self.photo
+    }
+
+    pub fn proid(&self) -> Option<&String> {
+        self.proid.as_ref()
+    }
+
+    pub fn related(&self) -> &Vec<String> {
+        &self.related
+    }
+
+    pub fn rev(&self) -> Option<&String> {
+        self.rev.as_ref()
+    }
+
+    pub fn role(&self) -> &Vec<String> {
+        &self.role
+    }
+
+    pub fn sound(&self) -> &Vec<String> {
+        &self.sound
+    }
+
+    pub fn tel(&self) -> &Vec<String> {
+        &self.tel
+    }
+
+    pub fn title(&self) -> &Vec<String> {
+        &self.title
+    }
+
+    pub fn tz(&self) -> &Vec<String> {
+        &self.tz
+    }
+
+    pub fn uid(&self) -> Option<&String> {
+        self.uid.as_ref()
+    }
+
+    pub fn url(&self) -> &Vec<String> {
+        &self.url
+    }
+
+    pub fn version(&self) -> Option<&String> {
+        self.version.as_ref()
+    }
+
+}
+

--- a/lib/domain/libimagcontact/src/deser.rs
+++ b/lib/domain/libimagcontact/src/deser.rs
@@ -24,93 +24,123 @@ use vobject::vcard::Vcard;
 pub struct DeserVcard {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     adr          : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     anniversary  : Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     bday         : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     categories   : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     clientpidmap : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     email        : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     fullname     : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     gender       : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     geo          : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     impp         : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     key          : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     lang         : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     logo         : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     member       : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     name         : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     nickname     : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     note         : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     org          : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     photo        : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     proid        : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     related      : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     rev          : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     role         : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     sound        : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     tel          : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     title        : Vec<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     tz           : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     uid          : Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     url          : Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     version      : Option<String>
 }
 

--- a/lib/domain/libimagcontact/src/error.rs
+++ b/lib/domain/libimagcontact/src/error.rs
@@ -32,6 +32,8 @@ error_chain! {
 
     foreign_links {
         Io(::std::io::Error);
+        TomlDe(::toml::de::Error);
+        TomlSer(::toml::ser::Error);
         TomlQueryError(::toml_query::error::Error);
         UuidError(::uuid::ParseError);
     }
@@ -43,14 +45,19 @@ error_chain! {
             display("Type error in header, expected {} at '{}', found other type", ty, loc)
         }
 
+        HeaderDataMissing(datapath: &'static str) {
+            description("Data missing in header")
+            display("Data missing in header at '{}'", datapath)
+        }
+
         EntryNotFound(sid: StoreId) {
             description("Entry not found with StoreId")
             display("Entry {:?} not found", sid)
         }
 
-        UidMissing(path: String) {
+        UidMissing(buf: String) {
             description("Vcard object has no UID")
-            display("Vcard at {:?} has no UID", path)
+            display("Vcard has no UID : {}", buf)
         }
 
     }

--- a/lib/domain/libimagcontact/src/error.rs
+++ b/lib/domain/libimagcontact/src/error.rs
@@ -26,7 +26,6 @@ error_chain! {
 
     links {
         StoreError(::libimagstore::error::StoreError, ::libimagstore::error::StoreErrorKind);
-        RefError(::libimagentryref::error::RefError, ::libimagentryref::error::RefErrorKind);
         VObjectError(::vobject::error::VObjectError, ::vobject::error::VObjectErrorKind);
         EntryUtilError(::libimagentryutil::error::EntryUtilError, ::libimagentryutil::error::EntryUtilErrorKind);
     }

--- a/lib/domain/libimagcontact/src/iter.rs
+++ b/lib/domain/libimagcontact/src/iter.rs
@@ -29,13 +29,6 @@ use error::Result;
 pub struct ContactIter<'a>(StoreIdIterator, &'a Store);
 
 /// Iterator over contacts
-///
-/// As the libimagcontact works with libimagentryref in the backend, we must hold a reference to the
-/// Store here as well, so we can check whether a fetched StoreId actually points to a contact
-/// reference or not.
-///
-/// So, the Iterator `Store::get()`s the object pointed to by the StoreId and returns it if
-/// everything worked.
 impl<'a> ContactIter<'a> {
 
     pub fn new(sii: StoreIdIterator, store: &'a Store) -> ContactIter<'a> {

--- a/lib/domain/libimagcontact/src/lib.rs
+++ b/lib/domain/libimagcontact/src/lib.rs
@@ -42,7 +42,6 @@ extern crate uuid;
 
 #[macro_use] extern crate libimagstore;
 extern crate libimagerror;
-extern crate libimagentryref;
 #[macro_use] extern crate libimagentryutil;
 
 module_entry_path_mod!("contact");

--- a/lib/domain/libimagcontact/src/lib.rs
+++ b/lib/domain/libimagcontact/src/lib.rs
@@ -33,12 +33,16 @@
     while_true,
 )]
 
+#![recursion_limit="128"]
+
 #[macro_use] extern crate log;
 #[macro_use] extern crate error_chain;
 extern crate vobject;
 extern crate toml;
 extern crate toml_query;
 extern crate uuid;
+extern crate serde;
+#[macro_use] extern crate serde_derive;
 
 #[macro_use] extern crate libimagstore;
 extern crate libimagerror;
@@ -50,15 +54,6 @@ pub mod contact;
 pub mod error;
 pub mod iter;
 pub mod store;
-mod util;
-
-
-#[cfg(feature = "serde")]
-extern crate serde;
-
-#[cfg(feature = "serde")]
-#[macro_use] extern crate serde_derive;
-
-#[cfg(feature = "deser")]
 pub mod deser;
+mod util;
 

--- a/lib/domain/libimagcontact/src/store.rs
+++ b/lib/domain/libimagcontact/src/store.rs
@@ -17,18 +17,24 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-use std::path::Path;
 use std::path::PathBuf;
-use std::result::Result as RResult;
 
-use vobject::parse_component;
+use toml::Value;
+use toml::to_string as toml_to_string;
+use toml::from_str as toml_from_str;
+use toml_query::insert::TomlValueInsertExt;
+use vobject::vcard::Vcard;
 
+use libimagstore::storeid::IntoStoreId;
+use libimagstore::storeid::StoreId;
 use libimagstore::store::Store;
 use libimagstore::store::FileLockEntry;
 use libimagstore::storeid::StoreIdIterator;
 use libimagentryutil::isa::Is;
 
 use contact::IsContact;
+use deser::DeserVcard;
+use module_path::ModuleEntryPath;
 use error::ContactError as CE;
 use error::ContactErrorKind as CEK;
 use error::Result;
@@ -38,10 +44,11 @@ pub trait ContactStore<'a> {
 
     // creating
 
-    fn create_from_path(&'a self, p: &PathBuf) -> Result<FileLockEntry<'a>>;
+    fn create_from_path(&'a self, p: &PathBuf)   -> Result<FileLockEntry<'a>>;
+    fn retrieve_from_path(&'a self, p: &PathBuf) -> Result<FileLockEntry<'a>>;
 
-    /// Create contact ref from buffer
-    fn create_from_buf(&'a self, buf: &String) -> Result<FileLockEntry<'a>>;
+    fn create_from_buf(&'a self, buf: &str)      -> Result<FileLockEntry<'a>>;
+    fn retrieve_from_buf(&'a self, buf: &str)    -> Result<FileLockEntry<'a>>;
 
     // getting
 
@@ -55,12 +62,19 @@ impl<'a> ContactStore<'a> for Store {
         util::read_to_string(p).and_then(|buf| self.create_from_buf(&buf))
     }
 
-    /// Create contact ref from buffer
-    fn create_from_buf(&'a self, buf: &String) -> Result<FileLockEntry<'a>> {
-        let component = parse_component(&buf)?;
-        debug!("Parsed: {:?}", component);
+    fn retrieve_from_path(&'a self, p: &PathBuf) -> Result<FileLockEntry<'a>> {
+        util::read_to_string(p).and_then(|buf| self.retrieve_from_buf(&buf))
+    }
 
-        unimplemented!()
+    /// Create contact ref from buffer
+    fn create_from_buf(&'a self, buf: &str) -> Result<FileLockEntry<'a>> {
+        let (sid, value) = prepare_fetching_from_store(buf)?;
+        postprocess_fetched_entry(self.create(sid)?, value)
+    }
+
+    fn retrieve_from_buf(&'a self, buf: &str) -> Result<FileLockEntry<'a>> {
+        let (sid, value) = prepare_fetching_from_store(buf)?;
+        postprocess_fetched_entry(self.retrieve(sid)?, value)
     }
 
     fn all_contacts(&'a self) -> Result<StoreIdIterator> {
@@ -72,5 +86,32 @@ impl<'a> ContactStore<'a> for Store {
         Ok(StoreIdIterator::new(Box::new(iter)))
     }
 
+}
+
+/// Prepare the fetching from the store.
+///
+/// That means calculating the StoreId and the Value from the vcard data
+fn prepare_fetching_from_store(buf: &str) -> Result<(StoreId, Value)> {
+    let vcard = Vcard::build(&buf)?;
+    debug!("Parsed: {:?}", vcard);
+
+    let uid = vcard.uid().ok_or_else(|| CE::from_kind(CEK::UidMissing(buf.to_string())))?;
+
+    let value = { // dirty ugly hack
+        let serialized = DeserVcard::from(vcard);
+        let serialized = toml_to_string(&serialized)?;
+        toml_from_str::<Value>(&serialized)?
+    };
+
+    let sid = ModuleEntryPath::new(uid.raw()).into_storeid()?;
+
+    Ok((sid, value))
+}
+
+/// Postprocess the entry just fetched from the store
+fn postprocess_fetched_entry<'a>(mut entry: FileLockEntry<'a>, value: Value) -> Result<FileLockEntry<'a>> {
+    entry.set_isflag::<IsContact>()?;
+    entry.get_header_mut().insert("contact.data", value)?;
+    Ok(entry)
 }
 

--- a/lib/domain/libimagcontact/src/util.rs
+++ b/lib/domain/libimagcontact/src/util.rs
@@ -24,8 +24,6 @@ use std::io::Read;
 
 use error::Result;
 
-use vobject::Component;
-
 pub fn read_to_string<A: AsRef<Path> + Debug>(pb: A) -> Result<String> {
     let mut cont = String::new();
 
@@ -35,11 +33,5 @@ pub fn read_to_string<A: AsRef<Path> + Debug>(pb: A) -> Result<String> {
     debug!("Read {} bytes from {:?}", bytes, pb);
 
     Ok(cont)
-}
-
-/// Helper for chaining results nicely
-pub fn parse(buf: String) -> Result<Component> {
-    use vobject::parse_component;
-    parse_component(&buf).map_err(From::from)
 }
 


### PR DESCRIPTION
This rewrites `libimagcontact` to be not based on `libimagentryref`.

And it rewrites `imag-contact` to work with the new interface.

---

Closes #1448 