### PR TITLE
libimagstore: Do not collect in Iterators

### DIFF
--- a/bin/core/imag-edit/src/main.rs
+++ b/bin/core/imag-edit/src/main.rs
@@ -89,7 +89,7 @@ fn main() {
     let edit_header = rt.cli().is_present("edit-header");
     let edit_header_only = rt.cli().is_present("edit-header-only");
 
-    StoreIdIterator::new(Box::new(sids.into_iter()))
+    StoreIdIterator::new(Box::new(sids.into_iter().map(Ok)))
         .into_get_iter(rt.store())
         .trace_unwrap_exit(1)
         .map(|o| o.unwrap_or_else(|| {

--- a/bin/core/imag-ids/src/main.rs
+++ b/bin/core/imag-ids/src/main.rs
@@ -45,6 +45,7 @@ use filters::filter::Filter;
 
 use libimagrt::setup::generate_runtime_setup;
 use libimagerror::trace::MapErrTrace;
+use libimagerror::iter::TraceIterator;
 use libimagerror::exit::ExitUnwrap;
 use libimagerror::io::ToExitCode;
 use libimagstore::storeid::StoreId;
@@ -86,6 +87,7 @@ fn main() {
     rt.store()
         .entries()
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .filter(|id| collection_filter.filter(id))
         .map(|id| if print_storepath {
             id

--- a/bin/core/imag-link/src/main.rs
+++ b/bin/core/imag-link/src/main.rs
@@ -54,7 +54,6 @@ extern crate libimagutil;
 
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::exit;
 
 use libimagentrylink::external::ExternalLinker;
 use libimagentrylink::internal::InternalLinker;
@@ -255,12 +254,11 @@ fn unlink(rt: &Runtime) {
         .map(PathBuf::from)
         .collect::<Vec<PathBuf>>().into_iter() // for lifetime inference
         .map(StoreId::new_baseless)
-        .unwrap_with(|e| { trace_error(&e); exit(1) })
         .into_get_iter(rt.store())
-        .unwrap_with(|e| { trace_error(&e); exit(1) })
-        .filter_map(|e| e)
+        .trace_unwrap_exit(1)
+        .filter_map(|x| x)
         .map(|mut entry| entry.unlink(rt.store()))
-        .unwrap_with(|e| { trace_error(&e); exit(1) })
+        .trace_unwrap_exit(1)
         .collect::<Vec<_>>();
 }
 

--- a/bin/domain/imag-diary/src/list.rs
+++ b/bin/domain/imag-diary/src/list.rs
@@ -23,6 +23,7 @@ use libimagdiary::diary::Diary;
 use libimagrt::runtime::Runtime;
 use libimagutil::warn_exit::warn_exit;
 use libimagerror::trace::MapErrTrace;
+use libimagerror::iter::TraceIterator;
 use libimagerror::io::ToExitCode;
 use libimagerror::exit::ExitUnwrap;
 use libimagutil::debug_result::*;
@@ -40,6 +41,7 @@ pub fn list(rt: &Runtime) {
     let mut ids = Diary::entries(rt.store(), &diaryname)
         .map_dbg_str("Ok")
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .map(|id| DiaryId::from_storeid(&id))
         .collect::<Result<Vec<_>>>()
         .map_err_trace_exit_unwrap(1);

--- a/bin/domain/imag-diary/src/view.rs
+++ b/bin/domain/imag-diary/src/view.rs
@@ -21,6 +21,7 @@ use libimagdiary::diary::Diary;
 use libimagdiary::viewer::DiaryViewer as DV;
 use libimagrt::runtime::Runtime;
 use libimagerror::trace::MapErrTrace;
+use libimagerror::iter::TraceIterator;
 use libimagutil::warn_exit::warn_exit;
 use libimagstore::iter::get::StoreIdGetIteratorExtension;
 use libimagentryview::viewer::Viewer;
@@ -34,7 +35,7 @@ pub fn view(rt: &Runtime) {
     let entries = Diary::entries(rt.store(), &diaryname)
         .map_err_trace_exit_unwrap(1)
         .into_get_iter(rt.store())
-        .filter_map(Result::ok)
+        .trace_unwrap_exit(1)
         .map(|e| e.unwrap_or_else(|| {
             error!("Failed to fetch entry");
             ::std::process::exit(1)

--- a/bin/domain/imag-habit/src/main.rs
+++ b/bin/domain/imag-habit/src/main.rs
@@ -57,6 +57,7 @@ use prettytable::row::Row;
 use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
 use libimagerror::trace::{MapErrTrace, trace_error};
+use libimagerror::iter::TraceIterator;
 use libimagerror::exit::ExitUnwrap;
 use libimagerror::io::ToExitCode;
 use libimaghabit::store::HabitStore;
@@ -167,6 +168,7 @@ fn delete(rt: &Runtime) {
         .store()
         .all_habit_templates()
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .map(|sid| (sid.clone(), rt.store().get(sid).map_err_trace_exit_unwrap(1))) // get the FileLockEntry
         .filter(|&(_, ref habit)| match habit { // filter for name of habit == name we look for
             &Some(ref h) => h.habit_name().map_err_trace_exit_unwrap(1) == name,
@@ -198,6 +200,7 @@ fn delete(rt: &Runtime) {
                 fle
                     .linked_instances()
                     .map_err_trace_exit_unwrap(1)
+                    .trace_unwrap_exit(1)
                     .filter_map(get_instance)
                     .filter(has_template_name)
                     .map(instance_location)
@@ -249,6 +252,7 @@ fn today(rt: &Runtime, future: bool) {
             .store()
             .all_habit_templates()
             .map_err_trace_exit_unwrap(1)
+            .trace_unwrap_exit(1)
             .filter_map(|id| match rt.store().get(id.clone()) {
                 Ok(Some(h)) => Some(h),
                 Ok(None) => {
@@ -396,6 +400,7 @@ fn list(rt: &Runtime) {
         .store()
         .all_habit_templates()
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .filter_map(|id| match rt.store().get(id.clone()) {
             Ok(Some(h)) => Some(h),
             Ok(None) => {
@@ -451,6 +456,7 @@ fn show(rt: &Runtime) {
         .store()
         .all_habit_templates()
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .filter_map(|id| get_from_store(rt.store(), id))
         .filter(|h| h.habit_name().map(|n| name == n).map_err_trace_exit_unwrap(1))
         .enumerate()
@@ -474,6 +480,7 @@ fn show(rt: &Runtime) {
             let _ = habit
                 .linked_instances()
                 .map_err_trace_exit_unwrap(1)
+                .trace_unwrap_exit(1)
                 .filter_map(|instance_id| {
                     debug!("Getting: {:?}", instance_id);
                     rt.store().get(instance_id).map_err_trace_exit_unwrap(1)
@@ -505,6 +512,7 @@ fn done(rt: &Runtime) {
             .store()
             .all_habit_templates()
             .map_err_trace_exit_unwrap(1)
+            .trace_unwrap_exit(1)
             .filter_map(|id| get_from_store(rt.store(), id))
             .filter(|h| {
                 let due = h.next_instance_date().map_err_trace_exit_unwrap(1);

--- a/bin/domain/imag-mail/src/main.rs
+++ b/bin/domain/imag-mail/src/main.rs
@@ -43,6 +43,7 @@ extern crate libimagutil;
 use std::io::Write;
 
 use libimagerror::trace::{MapErrTrace, trace_error};
+use libimagerror::iter::TraceIterator;
 use libimagerror::exit::ExitUnwrap;
 use libimagerror::io::ToExitCode;
 use libimagmail::mail::Mail;
@@ -143,6 +144,7 @@ fn list(rt: &Runtime) {
     let _ = rt.store()
         .entries()
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .filter(|id| id.is_in_collection(&["mail"]))
         .filter_map(|id| {
             rt.store()

--- a/bin/domain/imag-todo/src/main.rs
+++ b/bin/domain/imag-todo/src/main.rs
@@ -50,6 +50,7 @@ use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
 use libimagtodo::taskstore::TaskStore;
 use libimagerror::trace::{MapErrTrace, trace_error};
+use libimagerror::iter::TraceIterator;
 use libimagerror::exit::ExitUnwrap;
 use libimagerror::io::ToExitCode;
 
@@ -124,7 +125,7 @@ fn list(rt: &Runtime) {
     let res = rt.store().all_tasks() // get all tasks
         .map(|iter| { // and if this succeeded
             // filter out the ones were we can read the uuid
-            let uuids : Vec<_> = iter.filter_map(|storeid| {
+            let uuids : Vec<_> = iter.trace_unwrap_exit(1).filter_map(|storeid| {
                 match rt.store().retrieve(storeid) {
                     Ok(fle) => {
                         match fle.get_header().read_string("todo.uuid") {

--- a/bin/domain/imag-wiki/src/main.rs
+++ b/bin/domain/imag-wiki/src/main.rs
@@ -34,6 +34,7 @@ use std::io::Write;
 
 use libimagrt::runtime::Runtime;
 use libimagrt::setup::generate_runtime_setup;
+use libimagerror::iter::TraceIterator;
 use libimagerror::trace::MapErrTrace;
 use libimagerror::exit::ExitUnwrap;
 use libimagerror::io::ToExitCode;
@@ -90,6 +91,7 @@ fn ids(rt: &Runtime, wiki_name: &str) {
         })
         .all_ids()
         .map_err_trace_exit_unwrap(1)
+        .trace_unwrap_exit(1)
         .for_each(|id| {
             let _ = writeln!(outlock, "{}{}", prefix, id)
                 .to_exit_code()

--- a/lib/core/libimagrt/src/runtime.rs
+++ b/lib/core/libimagrt/src/runtime.rs
@@ -22,6 +22,7 @@ use std::process::Command;
 use std::env;
 use std::process::exit;
 use std::io::Stdin;
+use std::sync::Arc;
 
 pub use clap::App;
 use clap::AppSettings;
@@ -132,7 +133,7 @@ impl<'a> Runtime<'a> {
         let store_result = if cli_app.use_inmemory_fs() {
             Store::new_with_backend(storepath,
                                     &config,
-                                    Box::new(InMemoryFileAbstraction::default()))
+                                    Arc::new(InMemoryFileAbstraction::default()))
         } else {
             Store::new(storepath, &config)
         };

--- a/lib/core/libimagstore/src/file_abstraction/fs.rs
+++ b/lib/core/libimagstore/src/file_abstraction/fs.rs
@@ -168,20 +168,15 @@ impl FileAbstraction for FSFileAbstraction {
     fn pathes_recursively(&self, basepath: PathBuf) -> Result<PathIterator, SE> {
         use walkdir::WalkDir;
 
-        let i : Result<Vec<PathBuf>, SE> = WalkDir::new(basepath)
+        let i = WalkDir::new(basepath)
             .min_depth(1)
+            .max_open(100)
             .into_iter()
             .map(|r| {
-                r.map(|e| PathBuf::from(e.path()))
-                    .chain_err(|| SE::from_kind(SEK::FileError))
-            })
-            .fold(Ok(vec![]), |acc, e| {
-                acc.and_then(move |mut a| {
-                    a.push(e?);
-                    Ok(a)
-                })
+                r.map(|e| PathBuf::from(e.path())).chain_err(|| SE::from_kind(SEK::FileError))
             });
-        Ok(PathIterator::new(Box::new(i?.into_iter())))
+
+        Ok(PathIterator::new(Box::new(i)))
     }
 }
 

--- a/lib/core/libimagstore/src/file_abstraction/inmemory.rs
+++ b/lib/core/libimagstore/src/file_abstraction/inmemory.rs
@@ -183,15 +183,15 @@ impl FileAbstraction for InMemoryFileAbstraction {
 
     fn pathes_recursively(&self, _basepath: PathBuf) -> Result<PathIterator, SE> {
         debug!("Getting all pathes");
-        let keys : Vec<PathBuf> = self
+        let keys : Vec<Result<PathBuf, SE>> = self
             .backend()
             .lock()
             .map_err(|_| SE::from_kind(SEK::FileError))?
             .get_mut()
             .keys()
             .map(PathBuf::from)
-            .collect();
-        // we collect here as this happens only in tests and in memory anyways, so no problem
+            .map(Ok)
+            .collect(); // we have to collect() because of the lock() above.
 
         Ok(PathIterator::new(Box::new(keys.into_iter())))
     }

--- a/lib/core/libimagstore/src/file_abstraction/iter.rs
+++ b/lib/core/libimagstore/src/file_abstraction/iter.rs
@@ -19,19 +19,21 @@
 
 use std::path::PathBuf;
 
+use error::Result;
+
 /// A wrapper for an iterator over `PathBuf`s
-pub struct PathIterator(Box<Iterator<Item = PathBuf>>);
+pub struct PathIterator(Box<Iterator<Item = Result<PathBuf>>>);
 
 impl PathIterator {
 
-    pub fn new(iter: Box<Iterator<Item = PathBuf>>) -> PathIterator {
+    pub fn new(iter: Box<Iterator<Item = Result<PathBuf>>>) -> PathIterator {
         PathIterator(iter)
     }
 
 }
 
 impl Iterator for PathIterator {
-    type Item = PathBuf;
+    type Item = Result<PathBuf>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()

--- a/lib/core/libimagstore/src/file_abstraction/mod.rs
+++ b/lib/core/libimagstore/src/file_abstraction/mod.rs
@@ -27,7 +27,7 @@ use storeid::StoreId;
 
 mod fs;
 mod inmemory;
-mod iter;
+pub(crate) mod iter;
 
 pub use self::fs::FSFileAbstraction;
 pub use self::fs::FSFileAbstractionInstance;

--- a/lib/core/libimagstore/src/iter.rs
+++ b/lib/core/libimagstore/src/iter.rs
@@ -32,10 +32,10 @@ macro_rules! mk_iterator {
         use store::Store;
         use error::Result;
 
-        pub struct $itername<'a>(Box<Iterator<Item = StoreId> + 'a>, &'a Store);
+        pub struct $itername<'a>(Box<Iterator<Item = Result<StoreId>> + 'a>, &'a Store);
 
         impl<'a> $itername<'a> {
-            pub fn new(inner: Box<Iterator<Item = StoreId> + 'a>, store: &'a Store) -> Self {
+            pub fn new(inner: Box<Iterator<Item = Result<StoreId>> + 'a>, store: &'a Store) -> Self {
                 $itername(inner, store)
             }
         }
@@ -44,7 +44,7 @@ macro_rules! mk_iterator {
             type Item = Result<$yield>;
 
             fn next(&mut self) -> Option<Self::Item> {
-                self.0.next().map(|id| $fun(id, self.1))
+                self.0.next().map(|id| $fun(id?, self.1))
             }
         }
 
@@ -53,7 +53,7 @@ macro_rules! mk_iterator {
         }
 
         impl<'a, I> $extname<'a> for I
-            where I: Iterator<Item = StoreId> + 'a
+            where I: Iterator<Item = Result<StoreId>> + 'a
         {
             fn $extfnname(self, store: &'a Store) -> $itername<'a> {
                 $itername(Box::new(self), store)

--- a/lib/core/libimagstore/src/store.rs
+++ b/lib/core/libimagstore/src/store.rs
@@ -1202,12 +1202,13 @@ Hai
 #[cfg(test)]
 mod store_tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use super::Store;
     use file_abstraction::InMemoryFileAbstraction;
 
     pub fn get_store() -> Store {
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 
@@ -1390,10 +1391,11 @@ mod store_tests {
     #[test]
     fn test_swap_backend_during_runtime() {
         use file_abstraction::InMemoryFileAbstraction;
+        use std::sync::Arc;
 
         let mut store = {
             let backend = InMemoryFileAbstraction::default();
-            let backend = Box::new(backend);
+            let backend = Arc::new(backend);
 
             Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
         };
@@ -1409,7 +1411,7 @@ mod store_tests {
 
         {
             let other_backend = InMemoryFileAbstraction::default();
-            let other_backend = Box::new(other_backend);
+            let other_backend = Arc::new(other_backend);
 
             assert!(store.reset_backend(other_backend).is_ok())
         }

--- a/lib/core/libimagstore/src/store.rs
+++ b/lib/core/libimagstore/src/store.rs
@@ -741,25 +741,12 @@ impl Store {
     }
 
     /// Get _all_ entries in the store (by id as iterator)
-    pub fn entries<'a>(&'a self) -> Result<StoreIdIteratorWithStore<'a>> {
+    pub fn entries(&self) -> Result<StoreIdIteratorWithStore> {
         self.backend
             .pathes_recursively(self.path().clone())
-            .and_then(|iter| {
-                let mut elems = vec![];
-                for element in iter {
-                    let is_file = {
-                        let mut base = self.path().clone();
-                        base.push(element.clone());
-                        self.backend.is_file(&base)?
-                    };
-
-                    if is_file {
-                        let sid = StoreId::from_full_path(self.path(), element)?;
-                        elems.push(sid);
-                    }
-                }
-                Ok(StoreIdIteratorWithStore::new(Box::new(elems.into_iter()), self))
-            })
+            .map(|i| i.store_id_constructing(self.path().clone()))
+            .map(Box::new)
+            .map(|it| StoreIdIteratorWithStore::new(it, self))
     }
 
     /// Gets the path where this store is on the disk

--- a/lib/core/libimagstore/src/storeid.rs
+++ b/lib/core/libimagstore/src/storeid.rs
@@ -241,7 +241,7 @@ macro_rules! module_entry_path_mod {
 }
 
 pub struct StoreIdIterator {
-    iter: Box<Iterator<Item = StoreId>>,
+    iter: Box<Iterator<Item = Result<StoreId>>>,
 }
 
 impl Debug for StoreIdIterator {
@@ -254,16 +254,16 @@ impl Debug for StoreIdIterator {
 
 impl StoreIdIterator {
 
-    pub fn new(iter: Box<Iterator<Item = StoreId>>) -> StoreIdIterator {
+    pub fn new(iter: Box<Iterator<Item = Result<StoreId>>>) -> StoreIdIterator {
         StoreIdIterator { iter }
     }
 
 }
 
 impl Iterator for StoreIdIterator {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
-    fn next(&mut self) -> Option<StoreId> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 
@@ -280,16 +280,16 @@ impl<'a> Deref for StoreIdIteratorWithStore<'a> {
 }
 
 impl<'a> Iterator for StoreIdIteratorWithStore<'a> {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
-    fn next(&mut self) -> Option<StoreId> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 }
 
 impl<'a> StoreIdIteratorWithStore<'a> {
 
-    pub fn new(iter: Box<Iterator<Item = StoreId>>, store: &'a Store) -> Self {
+    pub fn new(iter: Box<Iterator<Item = Result<StoreId>>>, store: &'a Store) -> Self {
         StoreIdIteratorWithStore(StoreIdIterator::new(iter), store)
     }
 

--- a/lib/core/libimagstore/src/storeid.rs
+++ b/lib/core/libimagstore/src/storeid.rs
@@ -287,6 +287,8 @@ impl<'a> Iterator for StoreIdIteratorWithStore<'a> {
     }
 }
 
+use error::StoreError;
+
 impl<'a> StoreIdIteratorWithStore<'a> {
 
     pub fn new(iter: Box<Iterator<Item = Result<StoreId>>>, store: &'a Store) -> Self {
@@ -300,7 +302,7 @@ impl<'a> StoreIdIteratorWithStore<'a> {
     /// Transform the iterator into a StoreCreateIterator
     ///
     /// This immitates the API from `libimagstore::iter`.
-    pub fn into_create_iter(self) -> StoreCreateIterator<'a> {
+    pub fn into_create_iter(self) -> StoreCreateIterator<'a, StoreError> {
         StoreCreateIterator::new(Box::new(self.0), self.1)
     }
 
@@ -308,7 +310,7 @@ impl<'a> StoreIdIteratorWithStore<'a> {
     ///
     ///
     /// This immitates the API from `libimagstore::iter`.
-    pub fn into_delete_iter(self) -> StoreDeleteIterator<'a> {
+    pub fn into_delete_iter(self) -> StoreDeleteIterator<'a, StoreError> {
         StoreDeleteIterator::new(Box::new(self.0), self.1)
     }
 
@@ -316,7 +318,7 @@ impl<'a> StoreIdIteratorWithStore<'a> {
     ///
     ///
     /// This immitates the API from `libimagstore::iter`.
-    pub fn into_get_iter(self) -> StoreGetIterator<'a> {
+    pub fn into_get_iter(self) -> StoreGetIterator<'a, StoreError> {
         StoreGetIterator::new(Box::new(self.0), self.1)
     }
 
@@ -324,7 +326,7 @@ impl<'a> StoreIdIteratorWithStore<'a> {
     ///
     ///
     /// This immitates the API from `libimagstore::iter`.
-    pub fn into_retrieve_iter(self) -> StoreRetrieveIterator<'a> {
+    pub fn into_retrieve_iter(self) -> StoreRetrieveIterator<'a, StoreError> {
         StoreRetrieveIterator::new(Box::new(self.0), self.1)
     }
 

--- a/lib/domain/libimagcontact/src/iter.rs
+++ b/lib/domain/libimagcontact/src/iter.rs
@@ -43,8 +43,9 @@ impl<'a> Iterator for ContactIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self.0.next() {
-                None      => return None,
-                Some(sid) => match self.1.get(sid.clone()).map_err(From::from) {
+                None          => return None,
+                Some(Err(e))  => return Some(Err(e).map_err(CE::from)),
+                Some(Ok(sid)) => match self.1.get(sid.clone()).map_err(From::from) {
                     Err(e)          => return Some(Err(e)),
                     Ok(None)        => return Some(Err(CE::from_kind(CEK::EntryNotFound(sid)))),
                     Ok(Some(entry)) => match entry.is_contact().map_err(From::from) {

--- a/lib/domain/libimagcontact/src/store.rs
+++ b/lib/domain/libimagcontact/src/store.rs
@@ -81,7 +81,10 @@ impl<'a> ContactStore<'a> for Store {
         let iter = self
             .entries()?
             .without_store()
-            .filter(|id| id.is_in_collection(&["contact"]));
+            .filter(|id| match *id {
+                Ok(ref id) => id.is_in_collection(&["contact"]),
+                Err(_) => true,
+            });
 
         Ok(StoreIdIterator::new(Box::new(iter)))
     }

--- a/lib/domain/libimagdiary/src/diary.rs
+++ b/lib/domain/libimagdiary/src/diary.rs
@@ -94,13 +94,27 @@ impl Diary for Store {
             .chain_err(|| DEK::StoreReadError)
     }
 
+    /// get the id of the youngest entry
+    ///
+    /// TODO: We collect internally here. We shouldn't do that. Solution unclear.
     fn get_youngest_entry_id(&self, diary_name: &str) -> Option<Result<DiaryId>> {
+        use error::DiaryError as DE;
+
         match Diary::entries(self, diary_name) {
             Err(e) => Some(Err(e)),
             Ok(entries) => {
-                entries
-                    .map(|e| DiaryId::from_storeid(&e))
-                    .sorted_by(|a, b| {
+                let mut sorted_entries = vec![];
+
+                for entry in entries {
+                    let entry = match entry {
+                        Ok(e) => DiaryId::from_storeid(&e),
+                        Err(e) => return Some(Err(e).map_err(DE::from)),
+                    };
+
+                    sorted_entries.push(entry);
+                }
+
+                sorted_entries.into_iter().sorted_by(|a, b| {
                         match (a, b) {
                             (&Ok(ref a), &Ok(ref b)) => {
                                 let a : NaiveDateTime = a.clone().into();

--- a/lib/domain/libimaghabit/src/habit.rs
+++ b/lib/domain/libimaghabit/src/habit.rs
@@ -131,7 +131,8 @@ impl HabitTemplate for Entry {
         let iter = self
             .get_internal_links()?
             .map(|link| link.get_store_id().clone())
-            .filter(IsHabitCheck::is_habit_instance);
+            .filter(IsHabitCheck::is_habit_instance)
+            .map(Ok);
 
         let sidi = StoreIdIterator::new(Box::new(iter));
         Ok(HabitInstanceStoreIdIterator::new(sidi))

--- a/lib/domain/libimaghabit/src/iter.rs
+++ b/lib/domain/libimaghabit/src/iter.rs
@@ -22,16 +22,21 @@ use libimagstore::storeid::StoreIdIteratorWithStore;
 use libimagstore::storeid::StoreId;
 
 use util::IsHabitCheck;
+use error::Result;
+use error::HabitError as HE;
 
 pub struct HabitTemplateStoreIdIterator(StoreIdIterator);
 
 impl Iterator for HabitTemplateStoreIdIterator {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(n) = self.0.next() {
-            if n.is_habit_template() {
-                return Some(n)
+            match n {
+                Ok(n) => if n.is_habit_template() {
+                    return Some(Ok(n))
+                },
+                Err(e) => return Some(Err(e).map_err(HE::from)),
             }
         }
         None
@@ -59,12 +64,15 @@ impl HabitInstanceStoreIdIterator {
 }
 
 impl Iterator for HabitInstanceStoreIdIterator {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(n) = self.0.next() {
-            if n.is_habit_instance() {
-                return Some(n)
+            match n {
+                Ok(n) => if n.is_habit_instance() {
+                    return Some(Ok(n));
+                },
+                Err(e) => return Some(Err(e).map_err(HE::from)),
             }
         }
         None

--- a/lib/domain/libimagnotes/src/iter.rs
+++ b/lib/domain/libimagnotes/src/iter.rs
@@ -21,6 +21,8 @@ use libimagstore::storeid::StoreId;
 use libimagstore::storeid::StoreIdIterator;
 
 use notestoreid::*;
+use error::Result;
+use error::NoteError as NE;
 
 #[derive(Debug)]
 pub struct NoteIterator(StoreIdIterator);
@@ -34,12 +36,15 @@ impl NoteIterator {
 }
 
 impl Iterator for NoteIterator {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(n) = self.0.next() {
-            if n.is_note_id() {
-                return Some(n);
+            match n {
+                Ok(n) => if n.is_note_id() {
+                    return Some(Ok(n));
+                },
+                Err(e) => return Some(Err(e).map_err(NE::from)),
             }
         }
 

--- a/lib/domain/libimagtimetrack/src/iter/get.rs
+++ b/lib/domain/libimagtimetrack/src/iter/get.rs
@@ -37,12 +37,15 @@ impl<'a> Iterator for TimeTrackingsGetIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(next) = self.0.next() {
-            if next.is_in_collection(&[CRATE_NAME]) {
-                return match self.1.get(next) {
-                    Ok(Some(fle)) => Some(Ok(fle)),
-                    Ok(None)      => continue,
-                    Err(e)        => Some(Err(e))
-                };
+            match next {
+                Err(e)   => return Some(Err(e)),
+                Ok(next) => if next.is_in_collection(&[CRATE_NAME]) {
+                    return match self.1.get(next) {
+                        Ok(Some(fle)) => Some(Ok(fle)),
+                        Ok(None)      => continue,
+                        Err(e)        => Some(Err(e))
+                    };
+                }
             }
         }
 

--- a/lib/domain/libimagtimetrack/src/iter/mod.rs
+++ b/lib/domain/libimagtimetrack/src/iter/mod.rs
@@ -26,6 +26,8 @@ pub mod tag;
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use chrono::naive::NaiveDate;
 
     use libimagstore::store::Store;
@@ -37,7 +39,7 @@ mod test {
         use std::path::PathBuf;
         use libimagstore::file_abstraction::InMemoryFileAbstraction;
 
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 

--- a/lib/domain/libimagtodo/src/iter.rs
+++ b/lib/domain/libimagtodo/src/iter.rs
@@ -20,6 +20,9 @@
 use libimagstore::storeid::StoreIdIterator;
 use libimagstore::storeid::StoreId;
 
+use error::Result;
+use error::TodoError as TE;
+
 pub struct TaskIdIterator(StoreIdIterator);
 
 impl TaskIdIterator {
@@ -31,14 +34,15 @@ impl TaskIdIterator {
 }
 
 impl Iterator for TaskIdIterator {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self.0.next() {
                 None    => return None,
-                Some(n) => if n.is_in_collection(&["todo", "taskwarrior"]) {
-                    return Some(n)
+                Some(Err(e)) => return Some(Err(e).map_err(TE::from)),
+                Some(Ok(n)) => if n.is_in_collection(&["todo", "taskwarrior"]) {
+                    return Some(Ok(n))
                 }, // else continue
             }
         }

--- a/lib/domain/libimagwiki/src/wiki.rs
+++ b/lib/domain/libimagwiki/src/wiki.rs
@@ -108,12 +108,15 @@ impl<'a, 'b> Wiki<'a, 'b> {
 pub struct WikiIdIterator<'a>(StoreIdIteratorWithStore<'a>, IdIsInWikiFilter<'a>);
 
 impl<'a> Iterator for WikiIdIterator<'a> {
-    type Item = StoreId;
+    type Item = Result<StoreId>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(next) = self.0.next() {
-            if self.1.filter(&next) {
-                return Some(next)
+            match next {
+                Ok(next) => if self.1.filter(&next) {
+                    return Some(Ok(next));
+                },
+                Err(e) => return Some(Err(e).map_err(WE::from)),
             }
         }
 

--- a/lib/entry/libimagentryannotation/src/annotateable.rs
+++ b/lib/entry/libimagentryannotation/src/annotateable.rs
@@ -92,7 +92,7 @@ impl Annotateable for Entry {
     fn annotations<'a>(&self, store: &'a Store) -> Result<AnnotationIter<'a>> {
         self.get_internal_links()
             .map_err(From::from)
-            .map(|iter| StoreIdIterator::new(Box::new(iter.map(|e| e.get_store_id().clone()))))
+            .map(|iter| StoreIdIterator::new(Box::new(iter.map(|e| e.get_store_id().clone()).map(Ok))))
             .map(|i| AnnotationIter::new(i, store))
     }
 

--- a/lib/entry/libimagentrycategory/src/category.rs
+++ b/lib/entry/libimagentrycategory/src/category.rs
@@ -55,7 +55,7 @@ impl Category for Entry {
 
     fn get_entries<'a>(&self, store: &'a Store) -> Result<CategoryEntryIterator<'a>> {
         trace!("Getting linked entries for category '{:?}'", self.get_location());
-        let sit  = self.get_internal_links()?.map(|l| l.get_store_id().clone());
+        let sit  = self.get_internal_links()?.map(|l| l.get_store_id().clone()).map(Ok);
         let sit  = StoreIdIterator::new(Box::new(sit));
         let name = self.get_name()?;
         Ok(CategoryEntryIterator::new(store, sit, name))

--- a/lib/entry/libimagentrycategory/src/store.rs
+++ b/lib/entry/libimagentrycategory/src/store.rs
@@ -111,6 +111,7 @@ impl CategoryStore for Store {
 mod tests {
     extern crate env_logger;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use super::*;
 
@@ -118,7 +119,7 @@ mod tests {
 
     pub fn get_store() -> Store {
         use libimagstore::store::InMemoryFileAbstraction;
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 

--- a/lib/entry/libimagentrydatetime/src/datetime.rs
+++ b/lib/entry/libimagentrydatetime/src/datetime.rs
@@ -195,7 +195,7 @@ fn val_to_ndt(v: &Value) -> Result<NaiveDateTime> {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use toml_query::read::TomlValueReadExt;
+    use std::sync::Arc;
 
     use super::*;
 
@@ -204,10 +204,11 @@ mod tests {
     use chrono::naive::NaiveDateTime;
     use chrono::naive::NaiveDate;
     use chrono::naive::NaiveTime;
+    use toml_query::read::TomlValueReadExt;
 
     pub fn get_store() -> Store {
         use libimagstore::store::InMemoryFileAbstraction;
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 

--- a/lib/entry/libimagentrygps/src/entry.rs
+++ b/lib/entry/libimagentrygps/src/entry.rs
@@ -102,6 +102,7 @@ impl GPSEntry for Entry {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use libimagstore::store::Store;
 
@@ -113,7 +114,7 @@ mod tests {
 
     fn get_store() -> Store {
         use libimagstore::file_abstraction::InMemoryFileAbstraction;
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 

--- a/lib/entry/libimagentrylink/src/external.rs
+++ b/lib/entry/libimagentrylink/src/external.rs
@@ -406,6 +406,7 @@ impl ExternalLinker for Entry {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use libimagstore::store::Store;
 
@@ -416,7 +417,7 @@ mod tests {
 
     pub fn get_store() -> Store {
         use libimagstore::file_abstraction::InMemoryFileAbstraction;
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 

--- a/lib/entry/libimagentrylink/src/internal.rs
+++ b/lib/entry/libimagentrylink/src/internal.rs
@@ -772,6 +772,7 @@ pub mod store_check {
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use libimagstore::store::Store;
 
@@ -784,7 +785,7 @@ mod test {
 
     pub fn get_store() -> Store {
         use libimagstore::file_abstraction::InMemoryFileAbstraction;
-        let backend = Box::new(InMemoryFileAbstraction::default());
+        let backend = Arc::new(InMemoryFileAbstraction::default());
         Store::new_with_backend(PathBuf::from("/"), &None, backend).unwrap()
     }
 

--- a/lib/entry/libimagentrymarkdown/src/processor.rs
+++ b/lib/entry/libimagentrymarkdown/src/processor.rs
@@ -233,6 +233,7 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use libimagstore::store::Store;
     use libimagentrylink::internal::InternalLinker;
@@ -244,7 +245,7 @@ mod tests {
     pub fn get_store() -> Store {
         use libimagstore::file_abstraction::InMemoryFileAbstraction;
         let fs = InMemoryFileAbstraction::default();
-        Store::new_with_backend(PathBuf::from("/"), &None, Box::new(fs)).unwrap()
+        Store::new_with_backend(PathBuf::from("/"), &None, Arc::new(fs)).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Refactors the iterator API (and changes its interface).

The iterators did some `collect()` calls internally. With these patches, they do not do this anymore.

Ready, but the binaries are not yet refactored for this and thus might fail to compile.