### PR TITLE
Fix: Do not check whether path exists - check whether its a file

### DIFF
--- a/lib/core/libimagstore/src/file_abstraction/iter.rs
+++ b/lib/core/libimagstore/src/file_abstraction/iter.rs
@@ -63,7 +63,7 @@ impl Iterator for StoreIdConstructingIterator {
         while let Some(next) = self.0.next() {
             match next {
                 Err(e)  => return Some(Err(e)),
-                Ok(next) => match self.2.exists(&next) {
+                Ok(next) => match self.2.is_file(&next) {
                     Err(e)    => return Some(Err(e)),
                     Ok(true)  => return Some(StoreId::from_full_path(&self.1, next)),
                     Ok(false) => { continue },


### PR DESCRIPTION
This fixes a bug introduced in 195d921218559f98844e52cca2ebdfe12fcf6b71
where we didn't check whether the path is actually a file.