### PR TITLE
Revert "Deny non-absolut import pathes"

### DIFF
--- a/bin/domain/imag-contact/src/main.rs
+++ b/bin/domain/imag-contact/src/main.rs
@@ -162,11 +162,6 @@ fn import(rt: &Runtime) {
     let scmd = rt.cli().subcommand_matches("import").unwrap(); // secured by main
     let path = scmd.value_of("path").map(PathBuf::from).unwrap(); // secured by clap
 
-    if !path.is_absolute() {
-        error!("Import path must be absolute. Sorry.");
-        exit(1)
-    }
-
     if !path.exists() {
         error!("Path does not exist");
         exit(1)


### PR DESCRIPTION
This reverts commit b90abfb86814142b1483d9e540298607cf6894de.

Because `libimagcontact` is not based on `libimagentryref` anymore (as
of 2b10ab0b3627ea73cf4101112c035a81e2f1bd37), and thus does not put
pathes into the header, we can allow non-absolute pathes here.