### PR TITLE
Fix: Explicitely use Itertools::flatten()

### DIFF
--- a/lib/core/libimagrt/src/configuration.rs
+++ b/lib/core/libimagrt/src/configuration.rs
@@ -54,7 +54,7 @@ pub fn fetch_config(searchpath: &PathBuf) -> Result<Value> {
         base
     };
 
-    vec![
+    let vals = vec![
         vec![searchpath.clone()],
         gen_vars(searchpath, variants.clone(), &modifier),
 
@@ -63,8 +63,9 @@ pub fn fetch_config(searchpath: &PathBuf) -> Result<Value> {
 
         xdg_basedir::get_data_home().map(|data_dir| gen_vars(&data_dir, variants.clone(), &modifier))
                                     .unwrap_or(vec![]),
-    ].iter()
-        .flatten()
+    ];
+
+    Itertools::flatten(vals.iter())
         .filter(|path| path.exists() && path.is_file())
         .filter_map(|path| {
             let content = {


### PR DESCRIPTION
As of rustc 1.26, the `flatten()` method on iterators is preserved by
the rust standard library.
This could cause this code to hard-error some time in the future with
the `flatten()` function actually implemented by the standard library.

Hence we move to use the `Itertools::flatten()` function here
explicitely.

---

See https://github.com/rust-lang/rust/issues/48919
See https://github.com/rust-lang/rust/issues/48213