### PR TITLE
Update rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ matrix:
             - bash ./scripts/branch-contains-no-tmp-commits
             - bash ./scripts/version-updated
         - language: rust
-          rust: 1.25.0
+          rust: 1.26.0
           cache:
             cargo: true
           script:
             - cargo build --all --all-features -j 1  || exit 1
             - cargo test  --all --all-features -j 1  || exit 1
         - language: rust
-          rust: 1.26.0
+          rust: 1.27.2
           cache:
             cargo: true
           script:


### PR DESCRIPTION
As a dependency apparently requires rust 1.26 as minimum version, we
bump here.

Rust 1.28 is out already, so no problems with that!

---

Current master is broken because a dependency requires a new rust version. This fixes that issue.